### PR TITLE
Refactor/#121 timezone 문제 수정

### DIFF
--- a/src/main/java/com/skyhorsemanpower/auction/AuctionApplication.java
+++ b/src/main/java/com/skyhorsemanpower/auction/AuctionApplication.java
@@ -7,6 +7,8 @@ import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
+import java.util.TimeZone;
+
 
 @SpringBootApplication
 @EnableJpaRepositories
@@ -16,6 +18,9 @@ import org.springframework.data.mongodb.repository.config.EnableMongoRepositorie
 public class AuctionApplication {
 
 	public static void main(String[] args) {
+		// application 전체 timezone을 UTC로 설정
+		TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+
 		SpringApplication.run(AuctionApplication.class, args);
 	}
 

--- a/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
@@ -41,6 +41,7 @@ import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -85,7 +86,7 @@ public class AuctionServiceImpl implements AuctionService {
     private String generateAuctionUuid() {
         // 현재 날짜와 시간을 "yyyyMMddHHmm" 형식으로 포맷
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
-        String dateTime = LocalDateTime.now().format(formatter);
+        String dateTime = LocalDateTime.now(ZoneId.of("Asia/Seoul")).format(formatter);
 
         // UUID 생성 후 앞부분의 10자리 문자열 추출
         String uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 10);

--- a/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
@@ -287,10 +287,11 @@ public class AuctionServiceImpl implements AuctionService {
 
     @Override
     public void offerBiddingPrice(OfferBiddingPriceDto offerBiddingPriceDto) {
-        // 조건1. 경매 작성자는 경매에 참여할 수 없음
-        // 조건2. 마감 시간이 현재 시간보다 미래면 입찰 제시 가능
+        // 우선순위가 있는 입찰 조건
+        // 조건1. 마감 시간이 현재 시간보다 미래면 입찰 제시 가능
+        // 조건2. 경매 작성자는 경매에 참여할 수 없음
         // 조건3. 입찰 제시가가 최고 입찰가보다 커야한다.
-        if (!isAuctionSeller(offerBiddingPriceDto.getAuctionUuid(), offerBiddingPriceDto.getBiddingUuid()) && isAuctionActive(offerBiddingPriceDto.getAuctionUuid())
+        if (isAuctionActive(offerBiddingPriceDto.getAuctionUuid()) && !isAuctionSeller(offerBiddingPriceDto.getAuctionUuid(), offerBiddingPriceDto.getBiddingUuid())
                 && checkBiddingPrice(offerBiddingPriceDto.getBiddingUuid(), offerBiddingPriceDto.getAuctionUuid(), offerBiddingPriceDto.getBiddingPrice())) {
             AuctionHistory auctionHistory = AuctionHistory.builder()
                     .auctionUuid(offerBiddingPriceDto.getAuctionUuid())

--- a/src/main/java/com/skyhorsemanpower/auction/presentation/AuthorizationAuctionController.java
+++ b/src/main/java/com/skyhorsemanpower/auction/presentation/AuthorizationAuctionController.java
@@ -49,7 +49,8 @@ public class AuthorizationAuctionController {
     @Operation(summary = "경매글 이력 조회", description = "경매글 이력 조회")
     public SuccessResponse<List<CreatedAuctionHistoryResponseVo>> createdAuctionHistory(
             @RequestHeader String uuid) {
-        List<CreatedAuctionHistoryResponseVo> createdAuctionHistoryResponseVos = auctionService.createdAuctionHistory(CreatedAuctionHistoryDto.builder().sellerUuid(uuid).build());
+        List<CreatedAuctionHistoryResponseVo> createdAuctionHistoryResponseVos = auctionService.
+                createdAuctionHistory(CreatedAuctionHistoryDto.builder().sellerUuid(uuid).build());
         return new SuccessResponse<>(createdAuctionHistoryResponseVos);
     }
 
@@ -58,7 +59,8 @@ public class AuthorizationAuctionController {
     @Operation(summary = "참여한 경매 이력 조회", description = "참여한 경매 이력 조회")
     public SuccessResponse<List<ParticipatedAuctionHistoryResponseVo>> participatedAuctionHistory(
             @RequestHeader String uuid) {
-        List<ParticipatedAuctionHistoryResponseVo> participatedAuctionHistoryResponseVos = auctionService.participatedAuctionHistory(ParticipatedAuctionHistoryDto.builder().sellerUuid(uuid).build());
+        List<ParticipatedAuctionHistoryResponseVo> participatedAuctionHistoryResponseVos = auctionService.
+                participatedAuctionHistory(ParticipatedAuctionHistoryDto.builder().sellerUuid(uuid).build());
         return new SuccessResponse<>(participatedAuctionHistoryResponseVos);
     }
 }

--- a/src/main/java/com/skyhorsemanpower/auction/presentation/NonAuthorizationAuctionController.java
+++ b/src/main/java/com/skyhorsemanpower/auction/presentation/NonAuthorizationAuctionController.java
@@ -46,7 +46,8 @@ public class NonAuthorizationAuctionController {
     @GetMapping("/{auctionUuid}")
     @Operation(summary = "경매 상세 조회", description = "경매 상세 조회")
     public SuccessResponse<SearchAuctionResponseVo> searchAuction(@PathVariable("auctionUuid") String auctionUuid) {
-        SearchAuctionResponseVo searchAuctionResponseVo = auctionService.searchAuction(SearchAuctionDto.builder().auctionUuid(auctionUuid).build());
+        SearchAuctionResponseVo searchAuctionResponseVo = auctionService.searchAuction(SearchAuctionDto.builder()
+                .auctionUuid(auctionUuid).build());
         return new SuccessResponse<>(searchAuctionResponseVo);
     }
 
@@ -55,7 +56,8 @@ public class NonAuthorizationAuctionController {
     @Operation(summary = "경매 입찰 내역 조회", description = "경매 입찰 내역 조회")
     public Flux<AuctionHistory> searchBiddingPrice(
             @PathVariable("auctionUuid") String auctionUuid) {
-        return auctionService.searchBiddingPrice(SearchBiddingPriceDto.builder().auctionUuid(auctionUuid).build()).subscribeOn(Schedulers.boundedElastic());
+        return auctionService.searchBiddingPrice(SearchBiddingPriceDto.builder().auctionUuid(auctionUuid).build())
+                .subscribeOn(Schedulers.boundedElastic());
     }
 
     // 메인 페이지_통계


### PR DESCRIPTION
mongoDB에 저장할 경우, 실제 시간과 안 맞는 문제가 있었습니다.
스프링 애플리케이션의 기본 timezone을 "Asia/Seoul"로 설정하여도 mongoDB에 "UTC"로 변환되는 것을 확인했습니다.
서비스 간 일관성과 문제 발생을 고려해 스프링 애플리케이션의 기본 timezone을 "UTC"로 설정하였습니다.

서비스 중 AuctionUuid는 한국 시간에 맞게 조정해줬습니다.

프론트 측에 데이터 반환할 때 그대로 반환하고, 해당 시간의 timezone을 "Asia/Seoul"로 처리하기로 프론트엔드 측과 대화했습니다.

