### PR TITLE
Refactor/#111 경매글 조회 관련 기능들 최신순으로 조회하도록 리팩토링 진행

### DIFF
--- a/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
@@ -26,6 +26,7 @@ import org.quartz.SchedulerException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -163,7 +164,8 @@ public class AuctionServiceImpl implements AuctionService {
 
             // Todo 배포환경 테스트 필요
             // handle 값 통신되는지 확인 필요
-            String handle = getHandleByWebClientBlocking(readOnlyAuction.getSellerUuid());
+            String handle = "getHandleByWebClientBlocking(readOnlyAuction.getSellerUuid())";
+//            String handle = getHandleByWebClientBlocking(readOnlyAuction.getSellerUuid());
 
             // 로그인이 된 경우, 회원 서비스와 통신해서 구독 여부 획득
             // 기본값 false
@@ -214,7 +216,7 @@ public class AuctionServiceImpl implements AuctionService {
 
     // keyword, category 혼합 검색
     private Page<ReadOnlyAuction> searchAuctionByKeywordAndCategory(String keyword, String category, int page, int size) {
-        Page<ReadOnlyAuction> results = readOnlyAuctionRepository.findAllByTitleLikeAndCategory(keyword, category, PageRequest.of(page, size));
+        Page<ReadOnlyAuction> results = readOnlyAuctionRepository.findAllByTitleLikeAndCategoryOrderByCreatedAtDesc(keyword, category, PageRequest.of(page, size));
         // 조회 결과 있는 경우
         if (!results.isEmpty()) return results;
             // 조회 결과 없는 경우
@@ -224,7 +226,7 @@ public class AuctionServiceImpl implements AuctionService {
 
     // category 검색
     private Page<ReadOnlyAuction> searchAuctionByCategory(String category, int page, int size) {
-        Page<ReadOnlyAuction> results = readOnlyAuctionRepository.findAllByCategory(category, PageRequest.of(page, size));
+        Page<ReadOnlyAuction> results = readOnlyAuctionRepository.findAllByCategoryOrderByCreatedAtDesc(category, PageRequest.of(page, size));
         // 조회 결과 있는 경우
         if (!results.isEmpty()) return results;
             // 조회 결과 없는 경우
@@ -234,7 +236,7 @@ public class AuctionServiceImpl implements AuctionService {
 
     // keyword 검색
     private Page<ReadOnlyAuction> searchAuctionByKeyword(String keyword, int page, int size) {
-        Page<ReadOnlyAuction> results = readOnlyAuctionRepository.findAllByTitleLike(keyword, PageRequest.of(page, size));
+        Page<ReadOnlyAuction> results = readOnlyAuctionRepository.findAllByTitleLikeOrderByCreatedAtDesc(keyword, PageRequest.of(page, size));
         // 조회 결과 있는 경우
         if (!results.isEmpty()) return results;
             // 조회 결과 없는 경우
@@ -252,8 +254,8 @@ public class AuctionServiceImpl implements AuctionService {
         );
 
         Query query = new Query(criteria).with(pageable)
-                // 페이지 번호에 따라 결과를 건너뛴다.
-                .skip(pageable.getPageSize() * pageable.getPageNumber())
+                .with(Sort.by(Sort.Direction.DESC, "createdAt"))    // createdAt으로 내림차순 정렬
+                .skip(pageable.getPageSize() * pageable.getPageNumber())    // 페이지 번호에 따라 결과를 건너뛴다.
                 .limit(pageable.getPageSize());
 
         List<ReadOnlyAuction> filteredReadOnlyAuction = mongoTemplate.find(query, ReadOnlyAuction.class);

--- a/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
@@ -151,7 +151,8 @@ public class AuctionServiceImpl implements AuctionService {
         }
         // keyword, category 혼합 검색
         else if (!searchAuctionDto.getKeyword().isEmpty() && !searchAuctionDto.getCategory().isEmpty()){
-            readOnlyAuctionPage = searchAuctionByKeywordAndCategory(searchAuctionDto.getKeyword(), searchAuctionDto.getCategory(), page, size);
+            readOnlyAuctionPage = searchAuctionByKeywordAndCategory(searchAuctionDto.getKeyword(),
+                    searchAuctionDto.getCategory(), page, size);
         }
 
         readOnlyAuctions = readOnlyAuctionPage.getContent();
@@ -215,8 +216,10 @@ public class AuctionServiceImpl implements AuctionService {
 
 
     // keyword, category 혼합 검색
-    private Page<ReadOnlyAuction> searchAuctionByKeywordAndCategory(String keyword, String category, int page, int size) {
-        Page<ReadOnlyAuction> results = readOnlyAuctionRepository.findAllByTitleLikeAndCategoryOrderByCreatedAtDesc(keyword, category, PageRequest.of(page, size));
+    private Page<ReadOnlyAuction> searchAuctionByKeywordAndCategory(
+            String keyword, String category, int page, int size) {
+        Page<ReadOnlyAuction> results = readOnlyAuctionRepository
+                .findAllByTitleLikeAndCategoryOrderByCreatedAtDesc(keyword, category, PageRequest.of(page, size));
         // 조회 결과 있는 경우
         if (!results.isEmpty()) return results;
             // 조회 결과 없는 경우
@@ -226,7 +229,8 @@ public class AuctionServiceImpl implements AuctionService {
 
     // category 검색
     private Page<ReadOnlyAuction> searchAuctionByCategory(String category, int page, int size) {
-        Page<ReadOnlyAuction> results = readOnlyAuctionRepository.findAllByCategoryOrderByCreatedAtDesc(category, PageRequest.of(page, size));
+        Page<ReadOnlyAuction> results = readOnlyAuctionRepository
+                .findAllByCategoryOrderByCreatedAtDesc(category, PageRequest.of(page, size));
         // 조회 결과 있는 경우
         if (!results.isEmpty()) return results;
             // 조회 결과 없는 경우
@@ -236,7 +240,8 @@ public class AuctionServiceImpl implements AuctionService {
 
     // keyword 검색
     private Page<ReadOnlyAuction> searchAuctionByKeyword(String keyword, int page, int size) {
-        Page<ReadOnlyAuction> results = readOnlyAuctionRepository.findAllByTitleLikeOrderByCreatedAtDesc(keyword, PageRequest.of(page, size));
+        Page<ReadOnlyAuction> results = readOnlyAuctionRepository
+                .findAllByTitleLikeOrderByCreatedAtDesc(keyword, PageRequest.of(page, size));
         // 조회 결과 있는 경우
         if (!results.isEmpty()) return results;
             // 조회 결과 없는 경우
@@ -271,7 +276,8 @@ public class AuctionServiceImpl implements AuctionService {
 
     @Override
     public SearchAuctionResponseVo searchAuction(SearchAuctionDto searchAuctionDto) {
-        ReadOnlyAuction auction = readOnlyAuctionRepository.findByAuctionUuid(searchAuctionDto.getAuctionUuid()).orElseThrow(
+        ReadOnlyAuction auction = readOnlyAuctionRepository.findByAuctionUuid(
+                searchAuctionDto.getAuctionUuid()).orElseThrow(
                 () -> new CustomException(ResponseStatus.NO_DATA)
         );
 
@@ -293,8 +299,10 @@ public class AuctionServiceImpl implements AuctionService {
         // 조건1. 마감 시간이 현재 시간보다 미래면 입찰 제시 가능
         // 조건2. 경매 작성자는 경매에 참여할 수 없음
         // 조건3. 입찰 제시가가 최고 입찰가보다 커야한다.
-        if (isAuctionActive(offerBiddingPriceDto.getAuctionUuid()) && !isAuctionSeller(offerBiddingPriceDto.getAuctionUuid(), offerBiddingPriceDto.getBiddingUuid())
-                && checkBiddingPrice(offerBiddingPriceDto.getBiddingUuid(), offerBiddingPriceDto.getAuctionUuid(), offerBiddingPriceDto.getBiddingPrice())) {
+        if (isAuctionActive(offerBiddingPriceDto.getAuctionUuid()) &&
+                !isAuctionSeller(offerBiddingPriceDto.getAuctionUuid(), offerBiddingPriceDto.getBiddingUuid()) &&
+                checkBiddingPrice(offerBiddingPriceDto.getBiddingUuid(), offerBiddingPriceDto.getAuctionUuid(),
+                        offerBiddingPriceDto.getBiddingPrice())) {
             AuctionHistory auctionHistory = AuctionHistory.builder()
                     .auctionUuid(offerBiddingPriceDto.getAuctionUuid())
                     .biddingUuid(offerBiddingPriceDto.getBiddingUuid())
@@ -318,7 +326,8 @@ public class AuctionServiceImpl implements AuctionService {
     }
 
     private boolean checkBiddingPrice(String biddingUuid, String auctionUuid, int biddingPrice) {
-        Optional<CheckBiddingPriceProjection> optionalMaxBiddingPrice = auctionHistoryRepository.findMaxBiddingPriceByAuctionUuid(auctionUuid);
+        Optional<CheckBiddingPriceProjection> optionalMaxBiddingPrice = auctionHistoryRepository
+                .findMaxBiddingPriceByAuctionUuid(auctionUuid);
         int minimumBiddingPrice = readOnlyAuctionRepository.findByAuctionUuid(auctionUuid).orElseThrow(
                 () -> new CustomException(ResponseStatus.NO_DATA)
         ).getMinimumBiddingPrice();
@@ -350,12 +359,14 @@ public class AuctionServiceImpl implements AuctionService {
     }
 
     @Override
-    public List<CreatedAuctionHistoryResponseVo> createdAuctionHistory(CreatedAuctionHistoryDto createdAuctionHistoryDto) {
+    public List<CreatedAuctionHistoryResponseVo> createdAuctionHistory(
+            CreatedAuctionHistoryDto createdAuctionHistoryDto) {
         List<CreatedAuctionHistoryResponseVo> createdAuctionHistoryResponseVos = new ArrayList<>();
         CreatedAuctionHistoryResponseVo createdAuctionHistoryResponseVo = new CreatedAuctionHistoryResponseVo();
 
         // 최신순으로 자신의 경매 내역 조회
-        List<ReadOnlyAuction> auctions = readOnlyAuctionRepository.findAllBySellerUuidOrderByCreatedAtDesc(createdAuctionHistoryDto.getSellerUuid());
+        List<ReadOnlyAuction> auctions = readOnlyAuctionRepository
+                .findAllBySellerUuidOrderByCreatedAtDesc(createdAuctionHistoryDto.getSellerUuid());
 
         // 조회 결과 없는 경우
         if (auctions.isEmpty()) throw new CustomException(ResponseStatus.NO_DATA);
@@ -376,27 +387,34 @@ public class AuctionServiceImpl implements AuctionService {
     }
 
     @Override
-    public List<ParticipatedAuctionHistoryResponseVo> participatedAuctionHistory(ParticipatedAuctionHistoryDto participatedAuctionHistoryDto) {
+    public List<ParticipatedAuctionHistoryResponseVo> participatedAuctionHistory(
+            ParticipatedAuctionHistoryDto participatedAuctionHistoryDto) {
         List<ParticipatedAuctionHistoryResponseVo> participatedAuctionHistoryResponseVos = new ArrayList<>();
-        ParticipatedAuctionHistoryResponseVo participatedAuctionHistoryResponseVo = new ParticipatedAuctionHistoryResponseVo();
+        ParticipatedAuctionHistoryResponseVo participatedAuctionHistoryResponseVo =
+                new ParticipatedAuctionHistoryResponseVo();
 
         // 참여한 경매의 중복 제거한 auctionUuid 리스트 조회
-        List<ParticipatedAuctionHistoryProjection> participatedAuctionHistoryProjections = getAuctionUuidList(participatedAuctionHistoryDto.getSellerUuid());
+        List<ParticipatedAuctionHistoryProjection> participatedAuctionHistoryProjections =
+                getAuctionUuidList(participatedAuctionHistoryDto.getParticipateUuid());
 
         // auctionHistoryProjection 객체를 통해 auctionUuid를 반환
-        for (ParticipatedAuctionHistoryProjection participatedAuctionHistoryProjection : participatedAuctionHistoryProjections) {
+        for (ParticipatedAuctionHistoryProjection participatedAuctionHistoryProjection :
+                participatedAuctionHistoryProjections) {
             // thumbnail 호출
-            String thumbnail = auctionImagesRepository.getThumbnailUrl(participatedAuctionHistoryProjection.getAuctionUuid());
+            String thumbnail = auctionImagesRepository
+                    .getThumbnailUrl(participatedAuctionHistoryProjection.getAuctionUuid());
 
             // auction 엔티티 조회
-            ReadOnlyAuction auction = readOnlyAuctionRepository.findByAuctionUuid(participatedAuctionHistoryProjection.getAuctionUuid())
+            ReadOnlyAuction auction = readOnlyAuctionRepository
+                    .findByAuctionUuid(participatedAuctionHistoryProjection.getAuctionUuid())
                     .orElseThrow(
                             () -> new CustomException(ResponseStatus.NO_DATA)
                     );
 
             // Todo 배포환경 테스트 필요
             // 배포 환경에서 데이터 받아오는 지 확인 필요
-            String handle = getHandleByWebClientBlocking(auction.getSellerUuid());
+            String handle = "getHandleByWebClientBlocking(auction.getSellerUuid())";
+//            String handle = getHandleByWebClientBlocking(auction.getSellerUuid());
             participatedAuctionHistoryResponseVos.add(participatedAuctionHistoryResponseVo.toVo(auction, thumbnail, handle));
         }
         return participatedAuctionHistoryResponseVos;
@@ -556,8 +574,9 @@ public class AuctionServiceImpl implements AuctionService {
         return mainHighBiddingPriceAuctionResponseVos;
     }
 
-    private List<ParticipatedAuctionHistoryProjection> getAuctionUuidList(String sellerUuid) {
-        Query query = new Query(Criteria.where("biddingUuid").is(sellerUuid));
+    private List<ParticipatedAuctionHistoryProjection> getAuctionUuidList(String participateUuid) {
+        Query query = new Query(Criteria.where("biddingUuid").is(participateUuid))
+                .with(Sort.by(Sort.Direction.DESC, "biddingTime"));
 
         List<String> distinctAuctionUuids = mongoTemplate.query(AuctionHistory.class)
                 .distinct("auctionUuid")

--- a/src/main/java/com/skyhorsemanpower/auction/data/dto/ParticipatedAuctionHistoryDto.java
+++ b/src/main/java/com/skyhorsemanpower/auction/data/dto/ParticipatedAuctionHistoryDto.java
@@ -9,10 +9,10 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class ParticipatedAuctionHistoryDto {
-    private String sellerUuid;
+    private String participateUuid;
 
     @Builder
-    public ParticipatedAuctionHistoryDto(String sellerUuid) {
-        this.sellerUuid = sellerUuid;
+    public ParticipatedAuctionHistoryDto(String participateUuid) {
+        this.participateUuid = participateUuid;
     }
 }

--- a/src/main/java/com/skyhorsemanpower/auction/presentation/AuthorizationAuctionController.java
+++ b/src/main/java/com/skyhorsemanpower/auction/presentation/AuthorizationAuctionController.java
@@ -60,7 +60,7 @@ public class AuthorizationAuctionController {
     public SuccessResponse<List<ParticipatedAuctionHistoryResponseVo>> participatedAuctionHistory(
             @RequestHeader String uuid) {
         List<ParticipatedAuctionHistoryResponseVo> participatedAuctionHistoryResponseVos = auctionService.
-                participatedAuctionHistory(ParticipatedAuctionHistoryDto.builder().sellerUuid(uuid).build());
+                participatedAuctionHistory(ParticipatedAuctionHistoryDto.builder().participateUuid(uuid).build());
         return new SuccessResponse<>(participatedAuctionHistoryResponseVos);
     }
 }

--- a/src/main/java/com/skyhorsemanpower/auction/repository/cqrs/read/ReadOnlyAuctionRepository.java
+++ b/src/main/java/com/skyhorsemanpower/auction/repository/cqrs/read/ReadOnlyAuctionRepository.java
@@ -3,6 +3,7 @@ package com.skyhorsemanpower.auction.repository.cqrs.read;
 
 import com.skyhorsemanpower.auction.domain.cqrs.read.ReadOnlyAuction;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
@@ -12,15 +13,14 @@ import java.util.Optional;
 
 @Repository
 public interface ReadOnlyAuctionRepository extends MongoRepository<ReadOnlyAuction, String> {
-
-    Page<ReadOnlyAuction> findAllByTitleLike(String keyword, Pageable pageable);
-
+    
     Optional<ReadOnlyAuction> findByAuctionUuid(String auctionUuid);
-
-    Page<ReadOnlyAuction> findAllByCategory(String category, Pageable pageable);
-
-    Page<ReadOnlyAuction> findAllByTitleLikeAndCategory(String keyword, String category, Pageable pageable);
 
     List<ReadOnlyAuction> findAllBySellerUuidOrderByCreatedAtDesc(String sellerUuid);
 
+    Page<ReadOnlyAuction> findAllByTitleLikeOrderByCreatedAtDesc(String keyword, PageRequest of);
+
+    Page<ReadOnlyAuction> findAllByCategoryOrderByCreatedAtDesc(String category, PageRequest of);
+
+    Page<ReadOnlyAuction> findAllByTitleLikeAndCategoryOrderByCreatedAtDesc(String keyword, String category, PageRequest of);
 }


### PR DESCRIPTION
#111 

리팩토링한 기능들
- 경매 검색(성공)
- 경매글 이력 조회(성공)
- 참여한 경매 이력 조회(성공)
  - 참여한 경매는 경매의 "createdAt"을 최신순으로 할 필요가 없을 것 같음
  - 경매의 생성과 상관없이 경매 참여 시간이 더 중요한 듯 함.
  - "BiddingTime"을 기준으로 내림차순 진행
  - "BiddingTime"이 곧 저장된 몽고db에 저장된 순서이므로 해당 순서를 뒤집어서 조회하도록 진행