### PR TITLE
refactor: 경매글 상세 조회에서 구독 여부 추가(#134)

### DIFF
--- a/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
@@ -277,11 +277,22 @@ public class AuctionServiceImpl implements AuctionService {
         // handle 값 통신되는지 확인 필요
         String handle = getHandleByWebClientBlocking(auction.getSellerUuid());
 
+        // 구독 여부
+        boolean isSubscribed = false;
+
+        // 로그인이 된 경우
+        if(searchAuctionDto.getUuid() != null) {
+            isSubscribed = getIsSubscribedByWebClientBlocking(searchAuctionDto.getToken(),
+                    searchAuctionDto.getUuid(), searchAuctionDto.getAuctionUuid());
+        }
+
+        // 로그인이 안 된 경우는 false
         return SearchAuctionResponseVo.builder()
                 .readOnlyAuction(auction)
                 .handle(handle)
                 .thumbnail(auctionImagesRepository.getThumbnailUrl(searchAuctionDto.getAuctionUuid()))
                 .images(auctionImagesRepository.getImagesUrl(searchAuctionDto.getAuctionUuid()))
+                .isSubscribed(isSubscribed)
                 .build();
     }
 

--- a/src/main/java/com/skyhorsemanpower/auction/common/ServerPathEnum.java
+++ b/src/main/java/com/skyhorsemanpower/auction/common/ServerPathEnum.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ServerPathEnum {
-    MEMBER_SERVER("http://43.203.131.185:8000/member-service"),
+    MEMBER_SERVER("http://52.79.127.196:8000/member-service"),
     GET_HANDLE("/api/v1/non-authorization/users/datarequest"),
 
 

--- a/src/main/java/com/skyhorsemanpower/auction/data/dto/SearchAuctionDto.java
+++ b/src/main/java/com/skyhorsemanpower/auction/data/dto/SearchAuctionDto.java
@@ -10,9 +10,13 @@ import lombok.Setter;
 @NoArgsConstructor
 public class SearchAuctionDto {
     private String auctionUuid;
+    private String token;
+    private String uuid;
 
     @Builder
-    public SearchAuctionDto(String auctionUuid) {
+    public SearchAuctionDto(String auctionUuid, String token, String uuid) {
         this.auctionUuid = auctionUuid;
+        this.token = token;
+        this.uuid = uuid;
     }
 }

--- a/src/main/java/com/skyhorsemanpower/auction/data/vo/SearchAuctionResponseVo.java
+++ b/src/main/java/com/skyhorsemanpower/auction/data/vo/SearchAuctionResponseVo.java
@@ -17,13 +17,15 @@ public class SearchAuctionResponseVo {
     private String handle;
     private String thumbnail;
     private List<String> images;
+    private boolean isSubscribed;
 
     @Builder
-    public SearchAuctionResponseVo(ReadOnlyAuction readOnlyAuction, String handle, String thumbnail, List<String> images) {
+    public SearchAuctionResponseVo(ReadOnlyAuction readOnlyAuction, String handle, String thumbnail, List<String> images, boolean isSubscribed) {
         this.readOnlyAuction = readOnlyAuction;
         this.handle = handle;
         this.thumbnail = thumbnail;
         this.images = images;
+        this.isSubscribed = isSubscribed;
     }
 
     public void setHandle(String handle) {

--- a/src/main/java/com/skyhorsemanpower/auction/presentation/NonAuthorizationAuctionController.java
+++ b/src/main/java/com/skyhorsemanpower/auction/presentation/NonAuthorizationAuctionController.java
@@ -45,9 +45,12 @@ public class NonAuthorizationAuctionController {
     // auction_uuid를 통한 경매 상세 조회
     @GetMapping("/{auctionUuid}")
     @Operation(summary = "경매 상세 조회", description = "경매 상세 조회")
-    public SuccessResponse<SearchAuctionResponseVo> searchAuction(@PathVariable("auctionUuid") String auctionUuid) {
+    public SuccessResponse<SearchAuctionResponseVo> searchAuction(
+            @PathVariable("auctionUuid") String auctionUuid,
+            @RequestHeader(required = false) String authorization,
+            @RequestHeader(required = false) String uuid) {
         SearchAuctionResponseVo searchAuctionResponseVo = auctionService.searchAuction(SearchAuctionDto.builder()
-                .auctionUuid(auctionUuid).build());
+                .auctionUuid(auctionUuid).token(authorization).uuid(uuid).build());
         return new SuccessResponse<>(searchAuctionResponseVo);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
   profiles:
     active: none
   config:
-    import: optional:configserver:http://43.203.131.185:8071
+    import: optional:configserver:http://52.79.127.196:8071
 
   cloud:
     config:


### PR DESCRIPTION
경매글 상세 조회 API에 토큰 값과 uuid가 헤더에 담긴 경우, 경매글 상세 조회에서 구독 여부를 조회할 수 있습니다.

토큰 값과 uuid가 있는 경우에 구독 여부 통신 로직이 추가됐습니다.

![image](https://github.com/SKY-HORSE-MAN-POWER/BE_Auction/assets/128444378/b6de9b76-6224-43f6-9c46-6b4007604bf0)
