### PR TITLE
feat: 경매 참고 테이블 갱신 API 구현(#171)

### DIFF
--- a/src/main/java/com/skyhorsemanpower/auction/application/RedisService.java
+++ b/src/main/java/com/skyhorsemanpower/auction/application/RedisService.java
@@ -7,4 +7,6 @@ public interface RedisService {
     AuctionPageResponseVo getAuctionPage(String auctionUuid);
 
     StandbyResponseVo getStandbyPage(String auctionUuid);
+
+    void updateAuctionReferenceTable(String auctionUuid);
 }

--- a/src/main/java/com/skyhorsemanpower/auction/application/impl/RedisServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/auction/application/impl/RedisServiceImpl.java
@@ -1,10 +1,15 @@
 package com.skyhorsemanpower.auction.application.impl;
 
 import com.skyhorsemanpower.auction.application.RedisService;
+import com.skyhorsemanpower.auction.common.exception.CustomException;
+import com.skyhorsemanpower.auction.common.exception.ResponseStatus;
+import com.skyhorsemanpower.auction.common.redis.RedisVariableEnum;
 import com.skyhorsemanpower.auction.data.vo.AuctionPageResponseVo;
 import com.skyhorsemanpower.auction.data.vo.StandbyResponseVo;
+import com.skyhorsemanpower.auction.repository.AuctionHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -19,6 +24,7 @@ import java.util.Map;
 @Slf4j
 public class RedisServiceImpl implements RedisService {
     private final RedisTemplate<String, Object> redisTemplate;
+    private final AuctionHistoryRepository auctionHistoryRepository;
 
     @Override
     public AuctionPageResponseVo getAuctionPage(String auctionUuid) {
@@ -37,5 +43,41 @@ public class RedisServiceImpl implements RedisService {
 
         // 결과를 VO에 맞게 변환해서 반환
         return StandbyResponseVo.converter(resultMap);
+    }
+
+    @Override
+    public void updateAuctionReferenceTable(String auctionUuid) {
+        // redis 결과 조회
+        Map<Object, Object> resultMap = redisTemplate.opsForHash().entries(auctionUuid);
+        log.info("Before Updated Map >>> {}", resultMap);
+
+        // 데이터 갱신
+        try {
+            int round = Integer.parseInt((String) resultMap.get(RedisVariableEnum.ROUND.getVariable())) + 1;
+            BigDecimal currentPrice = new BigDecimal((String) resultMap.get(RedisVariableEnum.CURRENT_PRICE.getVariable()));
+            BigDecimal incrementUnit = new BigDecimal((String) resultMap.get(RedisVariableEnum.INCREMENT_UNIT.getVariable()));
+            currentPrice = currentPrice.add(incrementUnit);
+
+            DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME;
+            LocalDateTime currentRoundEndTime = LocalDateTime.parse((String) resultMap.get(RedisVariableEnum.CURRENT_ROUND_END_TIME.getVariable()), formatter);
+            LocalDateTime currentRoundStartTime = currentRoundEndTime.plusSeconds(15);
+            LocalDateTime newRoundEndTime = currentRoundStartTime.plusMinutes(1);
+
+            Map<Object, Object> map = new HashMap<>();
+            map.put(RedisVariableEnum.ROUND.getVariable(), String.valueOf(round));
+            map.put(RedisVariableEnum.CURRENT_PRICE.getVariable(), currentPrice.toString());
+            map.put(RedisVariableEnum.CURRENT_ROUND_START_TIME.getVariable(), currentRoundStartTime.format(formatter));
+            map.put(RedisVariableEnum.CURRENT_ROUND_END_TIME.getVariable(), newRoundEndTime.format(formatter));
+
+            // 갱신된 데이터를 다시 Redis에 저장
+            redisTemplate.opsForHash().putAll(auctionUuid, map);
+
+            // 결과 확인
+            resultMap = redisTemplate.opsForHash().entries(auctionUuid);
+            log.info("After Updated Map >>> {}", resultMap);
+        } catch (Exception e) {
+            log.warn("Update Value Is Not Exist.");
+            throw new CustomException(ResponseStatus.NO_DATA);
+        }
     }
 }

--- a/src/main/java/com/skyhorsemanpower/auction/application/impl/RedisServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/auction/application/impl/RedisServiceImpl.java
@@ -7,6 +7,9 @@ import com.skyhorsemanpower.auction.common.redis.RedisVariableEnum;
 import com.skyhorsemanpower.auction.data.vo.AuctionPageResponseVo;
 import com.skyhorsemanpower.auction.data.vo.StandbyResponseVo;
 import com.skyhorsemanpower.auction.repository.AuctionHistoryRepository;
+import com.skyhorsemanpower.auction.status.AuctionBidTimeEnum;
+import com.skyhorsemanpower.auction.status.StandbyTimeEnum;
+import com.skyhorsemanpower.auction.status.UpdateReferenceTableEnum;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.HashOperations;
@@ -59,9 +62,10 @@ public class RedisServiceImpl implements RedisService {
             currentPrice = currentPrice.add(incrementUnit);
 
             DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME;
-            LocalDateTime currentRoundEndTime = LocalDateTime.parse((String) resultMap.get(RedisVariableEnum.CURRENT_ROUND_END_TIME.getVariable()), formatter);
-            LocalDateTime currentRoundStartTime = currentRoundEndTime.plusSeconds(15);
-            LocalDateTime newRoundEndTime = currentRoundStartTime.plusMinutes(1);
+
+            // 다음 라운드 시작 시간은 입찰자 다 찬 순간에서 대기 시간의 합
+            LocalDateTime currentRoundStartTime = LocalDateTime.now().plusSeconds(StandbyTimeEnum.SECONDS_15.getSecond());
+            LocalDateTime newRoundEndTime = currentRoundStartTime.plusSeconds(AuctionBidTimeEnum.SECONDS_60.getSecond());
 
             Map<Object, Object> map = new HashMap<>();
             map.put(RedisVariableEnum.ROUND.getVariable(), String.valueOf(round));

--- a/src/main/java/com/skyhorsemanpower/auction/common/redis/RedisVariableEnum.java
+++ b/src/main/java/com/skyhorsemanpower/auction/common/redis/RedisVariableEnum.java
@@ -10,7 +10,8 @@ public enum RedisVariableEnum {
     CURRENT_ROUND_START_TIME("currentRoundStartTime"),
     CURRENT_ROUND_END_TIME("currentRoundEndTime"),
     CURRENT_PRICE("currentPrice"),
-    NUMBER_OF_EVENT_PARTICIPANTS("numberOfEventParticipants");
+    NUMBER_OF_EVENT_PARTICIPANTS("numberOfEventParticipants"),
+    INCREMENT_UNIT("incrementUnit");
 
     private final String variable;
 }

--- a/src/main/java/com/skyhorsemanpower/auction/presentation/AuctionController.java
+++ b/src/main/java/com/skyhorsemanpower/auction/presentation/AuctionController.java
@@ -55,9 +55,18 @@ public class AuctionController {
         return new SuccessResponse<>(redisService.getAuctionPage(auctionUuid));
     }
 
+    // 경매 참고 테이블 갱신 API
+    @PutMapping("/update-reference-table/{auctionUuid}")
+    @Operation(summary = "경매 참고 테이블 갱신 API", description = "입찰 남은 인원 수가 0이 되면 경매 참고 테이블 갱신")
+    public SuccessResponse<Object> updateAuctionReferenceTable(
+            @PathVariable("auctionUuid") String auctionUuid) {
+        redisService.updateAuctionReferenceTable(auctionUuid);
+        return new SuccessResponse<>(null);
+    }
+
     // 대기 페이지 API
     @PutMapping("/standby-page/{auctionUuid}")
-    @Operation(summary = "대기 페이지 API", description = "대기 페이지에 보여줄 데이터 조회 및 갱신")
+    @Operation(summary = "대기 페이지 API", description = "경매 참고 테이블 갱신 후 대기 페이지에 보여줄 데이터 조회 및 갱신")
     public SuccessResponse<StandbyResponseVo> standByPage(
             @PathVariable("auctionUuid") String auctionUuid) {
         return new SuccessResponse<>(redisService.getStandbyPage(auctionUuid));

--- a/src/main/java/com/skyhorsemanpower/auction/status/AuctionBidTimeEnum.java
+++ b/src/main/java/com/skyhorsemanpower/auction/status/AuctionBidTimeEnum.java
@@ -1,0 +1,13 @@
+package com.skyhorsemanpower.auction.status;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuctionBidTimeEnum {
+    SECONDS_90(90),
+    SECONDS_60(60),
+    SECONDS_30(30);
+    private final int second;
+}

--- a/src/main/java/com/skyhorsemanpower/auction/status/UpdateReferenceTableEnum.java
+++ b/src/main/java/com/skyhorsemanpower/auction/status/UpdateReferenceTableEnum.java
@@ -1,0 +1,12 @@
+package com.skyhorsemanpower.auction.status;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UpdateReferenceTableEnum {
+    SECONDS_15(15),
+    SECONDS_30(30);
+    private final int second;
+}


### PR DESCRIPTION
#171 

경매 참고 테이블 갱신 API 구현 했습니다.
해당 API는 입찰자가 다 찬 순간 갱신되는 것이기 때문에 다음 라운드 시작 시간은 현재 시간 + 대기시간으로 갱신됩니다.

아래 그림을 보시면 호출하는 순간을 기준으로 다음 라운드 시작시간이 갱신되는 것을 확인할 수 있습니다.

![image](https://github.com/SKY-HORSE-MAN-POWER/BE_Auction/assets/128444378/c12e076d-2f7c-4222-9701-519b700e77e7)
