### PR TITLE
feat: 경매 페이지 입장 시, SSE 연결 전 사용할 데이터 조회 API 구현(#175)

### DIFF
--- a/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
@@ -5,7 +5,7 @@ import com.skyhorsemanpower.auction.common.exception.CustomException;
 import com.skyhorsemanpower.auction.repository.AuctionHistoryRepository;
 import com.skyhorsemanpower.auction.common.exception.ResponseStatus;
 import com.skyhorsemanpower.auction.data.dto.*;
-import com.skyhorsemanpower.auction.domain.AuctionHistory;
+import com.skyhorsemanpower.auction.data.vo.domain.AuctionHistory;
 import com.skyhorsemanpower.auction.repository.AuctionHistoryReactiveRepository;
 import com.skyhorsemanpower.auction.repository.RoundInfoReactiveRepository;
 import com.skyhorsemanpower.auction.repository.RoundInfoRepository;

--- a/src/main/java/com/skyhorsemanpower/auction/data/vo/domain/AuctionHistory.java
+++ b/src/main/java/com/skyhorsemanpower/auction/data/vo/domain/AuctionHistory.java
@@ -1,4 +1,4 @@
-package com.skyhorsemanpower.auction.domain;
+package com.skyhorsemanpower.auction.data.vo.domain;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/skyhorsemanpower/auction/data/vo/domain/RoundInfo.java
+++ b/src/main/java/com/skyhorsemanpower/auction/data/vo/domain/RoundInfo.java
@@ -1,4 +1,4 @@
-package com.skyhorsemanpower.auction.domain;
+package com.skyhorsemanpower.auction.data.vo.domain;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -27,12 +27,12 @@ public class RoundInfo {
     private Boolean isActive;
     private Long numberOfParticipants;
     private Long leftNumberOfParticipants;
+    private LocalDateTime createdAt;
 
     @Builder
-
     public RoundInfo(String auctionUuid, Integer round, LocalDateTime roundStartTime, LocalDateTime roundEndTime,
                      BigDecimal incrementUnit, BigDecimal price, Boolean isActive, Long numberOfParticipants,
-                     Long leftNumberOfParticipants) {
+                     Long leftNumberOfParticipants, LocalDateTime createdAt) {
         this.auctionUuid = auctionUuid;
         this.round = round;
         this.roundStartTime = roundStartTime;
@@ -42,5 +42,6 @@ public class RoundInfo {
         this.isActive = isActive;
         this.numberOfParticipants = numberOfParticipants;
         this.leftNumberOfParticipants = leftNumberOfParticipants;
+        this.createdAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/skyhorsemanpower/auction/repository/AuctionHistoryReactiveRepository.java
+++ b/src/main/java/com/skyhorsemanpower/auction/repository/AuctionHistoryReactiveRepository.java
@@ -1,6 +1,6 @@
 package com.skyhorsemanpower.auction.repository;
 
-import com.skyhorsemanpower.auction.domain.AuctionHistory;
+import com.skyhorsemanpower.auction.data.vo.domain.AuctionHistory;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.data.mongodb.repository.Tailable;

--- a/src/main/java/com/skyhorsemanpower/auction/repository/AuctionHistoryRepository.java
+++ b/src/main/java/com/skyhorsemanpower/auction/repository/AuctionHistoryRepository.java
@@ -1,7 +1,7 @@
 package com.skyhorsemanpower.auction.repository;
 
 import com.skyhorsemanpower.auction.data.projection.CheckBiddingPriceProjection;
-import com.skyhorsemanpower.auction.domain.AuctionHistory;
+import com.skyhorsemanpower.auction.data.vo.domain.AuctionHistory;
 import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/skyhorsemanpower/auction/repository/RoundInfoReactiveRepository.java
+++ b/src/main/java/com/skyhorsemanpower/auction/repository/RoundInfoReactiveRepository.java
@@ -1,7 +1,7 @@
 package com.skyhorsemanpower.auction.repository;
 
 import com.skyhorsemanpower.auction.data.vo.RoundInfoResponseVo;
-import com.skyhorsemanpower.auction.domain.RoundInfo;
+import com.skyhorsemanpower.auction.data.vo.domain.RoundInfo;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.data.mongodb.repository.Tailable;

--- a/src/main/java/com/skyhorsemanpower/auction/repository/RoundInfoRepository.java
+++ b/src/main/java/com/skyhorsemanpower/auction/repository/RoundInfoRepository.java
@@ -1,7 +1,11 @@
 package com.skyhorsemanpower.auction.repository;
 
-import com.skyhorsemanpower.auction.domain.RoundInfo;
+import com.skyhorsemanpower.auction.data.vo.RoundInfoResponseVo;
+import com.skyhorsemanpower.auction.data.vo.domain.RoundInfo;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.Optional;
+
 public interface RoundInfoRepository extends MongoRepository<RoundInfo, String> {
+    Optional<RoundInfoResponseVo> findFirstByAuctionUuidOrderByCreatedAtDesc(String auctionUuid);
 }


### PR DESCRIPTION
#175 
경매 페이지 처음 들어간 경우에는 SSE 조회로 값을 못 받아오는 경우가 있을 수 있다 생각해 현재 데이터 조회 API를 구현합니다. 

페이지 처음 들어갔을 때, 화면에 보여줄 데이터라고 생각하시면 됩니다.

프론트랑 테스트하다가 사용할 필요 없다고 생각되면 삭제하겠습니다.

최신 것 잘 가져옵니다.
![image](https://github.com/SKY-HORSE-MAN-POWER/BE_Auction/assets/128444378/8107ce9a-b7fa-452f-8069-f36a4dfb3280)
