### PR TITLE
Feature/#179 경매 입찰 API 구현

### DIFF
--- a/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
@@ -90,8 +90,8 @@ public class AuctionServiceImpl implements AuctionService {
         log.info("남은 인원 통과");
 
         // 조건3. round 입찰가와 입력한 입찰가 확인
-        checkBiddingPrice(roundInfo.getPrice(), offerBiddingPriceDto.getBiddingPrice());
-        log.info("입찰가 통과");
+        checkRoundAndBiddingPrice(offerBiddingPriceDto, roundInfo);
+        log.info("라운드 및 입찰가 통과");
     }
 
     private void checkLeftNumberOfParticipant(Long leftNumberOfParticipants) {
@@ -99,11 +99,18 @@ public class AuctionServiceImpl implements AuctionService {
         if (leftNumberOfParticipants < 1L) throw new CustomException(ResponseStatus.FULL_PARTICIPANTS);
     }
 
-    private void checkBiddingPrice(BigDecimal price, BigDecimal biddingPrice) {
-        log.info("price >>> {}, biddingPrice >>> {}", price, biddingPrice);
-        log.info("biddingPrice.compareTo(price) == 0 >>> {}", biddingPrice.compareTo(price) == 0);
-        if (!(biddingPrice.compareTo(price) == 0)) {
-            throw new CustomException(ResponseStatus.NOT_EQUAL_PRICE);
+    private void checkRoundAndBiddingPrice(OfferBiddingPriceDto offerBiddingPriceDto, RoundInfo roundInfo) {
+        log.info("input round >>> {}, document round >>> {}, input price >>> {}, document price >>> {}",
+                offerBiddingPriceDto.getRound(), roundInfo.getRound(),
+                offerBiddingPriceDto.getBiddingPrice(), roundInfo.getPrice());
+
+        log.info("inputRound == documentRound >>> {}", offerBiddingPriceDto.getRound() == roundInfo.getRound());
+        log.info("inputPrice.compareTo(documentPrice) == 0 >>> {}",
+                offerBiddingPriceDto.getBiddingPrice().compareTo(roundInfo.getPrice()) == 0);
+
+        if (!(offerBiddingPriceDto.getBiddingPrice().compareTo(roundInfo.getPrice()) == 0) ||
+                !(offerBiddingPriceDto.getRound() == roundInfo.getRound())) {
+            throw new CustomException(ResponseStatus.NOT_EQUAL_ROUND_INFORMATION);
         }
     }
 

--- a/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
@@ -2,10 +2,11 @@ package com.skyhorsemanpower.auction.application.impl;
 
 import com.skyhorsemanpower.auction.application.AuctionService;
 import com.skyhorsemanpower.auction.common.exception.CustomException;
+import com.skyhorsemanpower.auction.domain.RoundInfo;
 import com.skyhorsemanpower.auction.repository.AuctionHistoryRepository;
 import com.skyhorsemanpower.auction.common.exception.ResponseStatus;
 import com.skyhorsemanpower.auction.data.dto.*;
-import com.skyhorsemanpower.auction.data.vo.domain.AuctionHistory;
+import com.skyhorsemanpower.auction.domain.AuctionHistory;
 import com.skyhorsemanpower.auction.repository.AuctionHistoryReactiveRepository;
 import com.skyhorsemanpower.auction.repository.RoundInfoReactiveRepository;
 import com.skyhorsemanpower.auction.repository.RoundInfoRepository;
@@ -13,6 +14,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Service
@@ -28,39 +32,68 @@ public class AuctionServiceImpl implements AuctionService {
 
     @Override
     public void offerBiddingPrice(OfferBiddingPriceDto offerBiddingPriceDto) {
-        // 우선순위가 있는 입찰 조건
-        // 조건1. 마감 시간이 현재 시간보다 미래면 입찰 제시 가능
-        // 조건2. 경매 작성자는 경매에 참여할 수 없음
-        // 조건3. 입찰 제시가가 최고 입찰가보다 커야한다.
-//        if (isAuctionActive(offerBiddingPriceDto.getAuctionUuid()) &&
-//                !isAuctionSeller(offerBiddingPriceDto.getAuctionUuid(), offerBiddingPriceDto.getBiddingUuid()) &&
-//                checkBiddingPrice(offerBiddingPriceDto.getBiddingUuid(), offerBiddingPriceDto.getAuctionUuid(),
-//                        offerBiddingPriceDto.getBiddingPrice())) {
-            AuctionHistory auctionHistory = AuctionHistory.builder()
-                    .auctionUuid(offerBiddingPriceDto.getAuctionUuid())
-                    .biddingUuid(offerBiddingPriceDto.getBiddingUuid())
-                    .biddingPrice(offerBiddingPriceDto.getBiddingPrice())
-                    .biddingTime(LocalDateTime.now())
-                    .build();
-            try {
-                auctionHistoryReactiveRepository.save(auctionHistory).subscribe();
-            } catch (Exception e) {
-                throw new CustomException(ResponseStatus.MONGODB_ERROR);
-            }
+        // 입찰 가능 확인
+        // 입찰이 안되면 아래 메서드 내에서 예외를 던진다.
+        isBiddingPossible(offerBiddingPriceDto);
+
+        // 입찰 정보 저장
+        AuctionHistory auctionHistory = AuctionHistory.converter(offerBiddingPriceDto);
+        log.info("Saved Auction History Information >>> {}", auctionHistory.toString());
+
+        try {
+            auctionHistoryRepository.save(auctionHistory);
+        } catch (Exception e) {
+            throw new CustomException(ResponseStatus.MONGODB_ERROR);
         }
-//        else throw new CustomException(ResponseStatus.CAN_NOT_BIDDING);
-//    }
-
-    private boolean isAuctionSeller(String auctionUuid, String biddingUuid) {
-        return true;
     }
 
-    private boolean checkBiddingPrice(String biddingUuid, String auctionUuid, int biddingPrice) {
-        return true;
+    @Transactional
+    private void isBiddingPossible(OfferBiddingPriceDto offerBiddingPriceDto) {
+        // 현재 경매의 라운드 정보 추출
+        RoundInfo roundInfo = roundInfoRepository.
+                findByAuctionUuidAndRound(offerBiddingPriceDto.getAuctionUuid(),
+                        offerBiddingPriceDto.getRound()).orElseThrow(
+                        () -> new CustomException(ResponseStatus.NO_DATA));
+
+        // 조건1. 입찰 시간 확인
+        checkBiddingTime(roundInfo.getRoundStartTime(), roundInfo.getRoundEndTime());
+        log.info("입찰 시간 통과");
+
+        // 조건2. 남은 인원이 1 이상
+        boolean isUpdateRoundInfo = checkLeftNumberOfParticipant(roundInfo.getLeftNumberOfParticipants());
+        log.info("남은 인원 통과");
+
+        // 조건3. round 입찰가와 입력한 입찰가 확인
+        checkBiddingPrice(roundInfo.getPrice(), offerBiddingPriceDto.getBiddingPrice());
+        log.info("입찰가 통과");
     }
 
-    private boolean isAuctionActive(String auctionUuid) {
-        return true;
+    private boolean checkLeftNumberOfParticipant(Long leftNumberOfParticipants) {
+        log.info("leftNumberOfParticipants >>> {}", leftNumberOfParticipants);
+        if (leftNumberOfParticipants < 1L) throw new CustomException(ResponseStatus.FULL_PARTICIPANTS);
+
+        // round_info 도큐먼트 갱신 트리거
+        log.info("Is Update round_info? >>> {}", leftNumberOfParticipants.equals(1L));
+        return leftNumberOfParticipants.equals(1L);
+    }
+
+    private void checkBiddingPrice(BigDecimal price, BigDecimal biddingPrice) {
+        log.info("price >>> {}, biddingPrice >>> {}", price, biddingPrice);
+        log.info("biddingPrice.compareTo(price) == 0 >>> {}", biddingPrice.compareTo(price) == 0);
+        if (!(biddingPrice.compareTo(price) == 0)) {
+            throw new CustomException(ResponseStatus.NOT_EQUAL_PRICE);
+        }
+    }
+
+    private void checkBiddingTime(LocalDateTime roundStartTime, LocalDateTime roundEndTime) {
+        log.info("roundStartTime >>> {}, now >>> {}, roundEndTime >>> {}",
+                roundStartTime, LocalDateTime.now(), roundEndTime);
+        log.info("roundStartTime.isBefore(LocalDateTime.now()) >>> {}, roundEndTime.isAfter(LocalDateTime.now()) >>> {}"
+                , roundStartTime.isBefore(LocalDateTime.now()), roundEndTime.isAfter(LocalDateTime.now()));
+        // roundStartTime <= 입찰 시간 <= roundEndTime
+        if (!(roundStartTime.isBefore(LocalDateTime.now()) && roundEndTime.isAfter(LocalDateTime.now()))) {
+            throw new CustomException(ResponseStatus.NOT_BIDDING_TIME);
+        }
     }
 
 }

--- a/src/main/java/com/skyhorsemanpower/auction/common/exception/ResponseStatus.java
+++ b/src/main/java/com/skyhorsemanpower/auction/common/exception/ResponseStatus.java
@@ -34,6 +34,12 @@ public enum ResponseStatus {
     // 경매 입찰 불가능
     CAN_NOT_BIDDING(404, "입찰이 불가능합니다."),
 
+    // 현재 입찰가와 주어진 입찰가가 다른 경우
+    NOT_EQUAL_PRICE(404, "현재 입찰가와 맞지 않습니다."),
+
+    // 입찰자를 다 모집한 경우
+    FULL_PARTICIPANTS(404, "현 라운드는 입찰자가 다 찼습니다."),
+
     // 예외 테스트 용
     EXCEPTION_TEST(500, "예외 테스트") ;
 

--- a/src/main/java/com/skyhorsemanpower/auction/common/exception/ResponseStatus.java
+++ b/src/main/java/com/skyhorsemanpower/auction/common/exception/ResponseStatus.java
@@ -34,8 +34,8 @@ public enum ResponseStatus {
     // 경매 입찰 불가능
     CAN_NOT_BIDDING(404, "입찰이 불가능합니다."),
 
-    // 현재 입찰가와 주어진 입찰가가 다른 경우
-    NOT_EQUAL_PRICE(404, "현재 입찰가와 맞지 않습니다."),
+    // 라운드 정보(입찰가, 라운드) 불일치
+    NOT_EQUAL_ROUND_INFORMATION(404, "라운드 또는 입찰가가 일치하지 않습니다."),
 
     // 입찰자를 다 모집한 경우
     FULL_PARTICIPANTS(404, "현 라운드는 입찰자가 다 찼습니다."),

--- a/src/main/java/com/skyhorsemanpower/auction/data/dto/OfferBiddingPriceDto.java
+++ b/src/main/java/com/skyhorsemanpower/auction/data/dto/OfferBiddingPriceDto.java
@@ -6,19 +6,23 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+import java.math.BigDecimal;
+
 @Getter
 @ToString
 @NoArgsConstructor
 public class OfferBiddingPriceDto {
     private String auctionUuid;
     private String biddingUuid;
-    private int biddingPrice;
+    private BigDecimal biddingPrice;
+    private int round;
 
     @Builder
-    public OfferBiddingPriceDto(String auctionUuid, String biddingUuid, int biddingPrice) {
+    public OfferBiddingPriceDto(String auctionUuid, String biddingUuid, BigDecimal biddingPrice, int round) {
         this.auctionUuid = auctionUuid;
         this.biddingUuid = biddingUuid;
         this.biddingPrice = biddingPrice;
+        this.round = round;
     }
 
     public static OfferBiddingPriceDto voToDto(OfferBiddingPriceRequestVo offerBiddingPriceRequestVo, String uuid) {
@@ -26,6 +30,7 @@ public class OfferBiddingPriceDto {
                 .auctionUuid(offerBiddingPriceRequestVo.getAuctionUuid())
                 .biddingUuid(uuid)
                 .biddingPrice(offerBiddingPriceRequestVo.getBiddingPrice())
+                .round(offerBiddingPriceRequestVo.getRound())
                 .build();
     }
 }

--- a/src/main/java/com/skyhorsemanpower/auction/data/vo/OfferBiddingPriceRequestVo.java
+++ b/src/main/java/com/skyhorsemanpower/auction/data/vo/OfferBiddingPriceRequestVo.java
@@ -3,9 +3,12 @@ package com.skyhorsemanpower.auction.data.vo;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.math.BigDecimal;
+
 @Getter
 @ToString
 public class OfferBiddingPriceRequestVo {
     private String auctionUuid;
-    private int biddingPrice;
+    private BigDecimal biddingPrice;
+    private int round;
 }

--- a/src/main/java/com/skyhorsemanpower/auction/domain/AuctionHistory.java
+++ b/src/main/java/com/skyhorsemanpower/auction/domain/AuctionHistory.java
@@ -1,5 +1,6 @@
-package com.skyhorsemanpower.auction.data.vo.domain;
+package com.skyhorsemanpower.auction.domain;
 
+import com.skyhorsemanpower.auction.data.dto.OfferBiddingPriceDto;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,6 +8,7 @@ import lombok.ToString;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Getter
@@ -19,17 +21,27 @@ public class AuctionHistory {
 
     private String auctionUuid;
     private String biddingUuid;
-    private int biddingPrice;
+    private BigDecimal biddingPrice;
     private LocalDateTime biddingTime;
     private Integer round;
 
     @Builder
-    public AuctionHistory(String auctionUuid, String biddingUuid, int biddingPrice,
+    public AuctionHistory(String auctionUuid, String biddingUuid, BigDecimal biddingPrice,
                           LocalDateTime biddingTime, Integer round) {
         this.auctionUuid = auctionUuid;
         this.biddingUuid = biddingUuid;
         this.biddingPrice = biddingPrice;
         this.biddingTime = biddingTime;
         this.round = round;
+    }
+
+    public static AuctionHistory converter(OfferBiddingPriceDto offerBiddingPriceDto) {
+        return AuctionHistory.builder()
+                .auctionUuid(offerBiddingPriceDto.getAuctionUuid())
+                .biddingUuid(offerBiddingPriceDto.getBiddingUuid())
+                .biddingPrice(offerBiddingPriceDto.getBiddingPrice())
+                .biddingTime(LocalDateTime.now())
+                .round(offerBiddingPriceDto.getRound())
+                .build();
     }
 }

--- a/src/main/java/com/skyhorsemanpower/auction/domain/RoundInfo.java
+++ b/src/main/java/com/skyhorsemanpower/auction/domain/RoundInfo.java
@@ -1,5 +1,7 @@
 package com.skyhorsemanpower.auction.domain;
 
+import com.skyhorsemanpower.auction.status.RoundTimeEnum;
+import com.skyhorsemanpower.auction.status.StandbyTimeEnum;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -43,5 +45,40 @@ public class RoundInfo {
         this.numberOfParticipants = numberOfParticipants;
         this.leftNumberOfParticipants = leftNumberOfParticipants;
         this.createdAt = LocalDateTime.now();
+    }
+
+    public static RoundInfo nextRoundUpdate(RoundInfo roundInfo) {
+        Integer nextRound = roundInfo.getRound() + 1;
+        LocalDateTime nextRoundStartTime = LocalDateTime.now().plusSeconds(StandbyTimeEnum.SECONDS_15.getSecond());
+        LocalDateTime nextRoundEndTime = nextRoundStartTime.plusSeconds(RoundTimeEnum.SECONDS_60.getSecond());
+        BigDecimal nextPrice = roundInfo.getPrice().add(roundInfo.getIncrementUnit());
+
+        return RoundInfo.builder()
+                .auctionUuid(roundInfo.getAuctionUuid())
+                .round(nextRound)
+                .roundStartTime(nextRoundStartTime)
+                .roundEndTime(nextRoundEndTime)
+                .incrementUnit(roundInfo.getIncrementUnit())
+                .price(nextPrice)
+                .isActive(true)
+                .numberOfParticipants(roundInfo.getNumberOfParticipants())
+                .leftNumberOfParticipants(roundInfo.getNumberOfParticipants())
+                .build();
+    }
+
+    public static RoundInfo currentRoundUpdate(RoundInfo roundInfo) {
+        Long nextNumberOfParticipants = roundInfo.getLeftNumberOfParticipants() - 1;
+
+        return RoundInfo.builder()
+                .auctionUuid(roundInfo.getAuctionUuid())
+                .round(roundInfo.getRound())
+                .roundStartTime(roundInfo.getRoundStartTime())
+                .roundEndTime(roundInfo.getRoundEndTime())
+                .incrementUnit(roundInfo.getIncrementUnit())
+                .price(roundInfo.getPrice())
+                .isActive(true)
+                .numberOfParticipants(roundInfo.getNumberOfParticipants())
+                .leftNumberOfParticipants(nextNumberOfParticipants)
+                .build();
     }
 }

--- a/src/main/java/com/skyhorsemanpower/auction/domain/RoundInfo.java
+++ b/src/main/java/com/skyhorsemanpower/auction/domain/RoundInfo.java
@@ -1,4 +1,4 @@
-package com.skyhorsemanpower.auction.data.vo.domain;
+package com.skyhorsemanpower.auction.domain;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/skyhorsemanpower/auction/presentation/AuctionController.java
+++ b/src/main/java/com/skyhorsemanpower/auction/presentation/AuctionController.java
@@ -9,7 +9,6 @@ import com.skyhorsemanpower.auction.data.dto.OfferBiddingPriceDto;
 import com.skyhorsemanpower.auction.data.vo.OfferBiddingPriceRequestVo;
 import com.skyhorsemanpower.auction.data.vo.RoundInfoResponseVo;
 import com.skyhorsemanpower.auction.data.vo.StandbyResponseVo;
-import com.skyhorsemanpower.auction.data.vo.domain.RoundInfo;
 import com.skyhorsemanpower.auction.repository.RoundInfoReactiveRepository;
 import com.skyhorsemanpower.auction.repository.RoundInfoRepository;
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,8 +18,6 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/skyhorsemanpower/auction/presentation/AuctionController.java
+++ b/src/main/java/com/skyhorsemanpower/auction/presentation/AuctionController.java
@@ -9,6 +9,7 @@ import com.skyhorsemanpower.auction.data.dto.OfferBiddingPriceDto;
 import com.skyhorsemanpower.auction.data.vo.OfferBiddingPriceRequestVo;
 import com.skyhorsemanpower.auction.data.vo.RoundInfoResponseVo;
 import com.skyhorsemanpower.auction.data.vo.StandbyResponseVo;
+import com.skyhorsemanpower.auction.domain.RoundInfo;
 import com.skyhorsemanpower.auction.repository.RoundInfoReactiveRepository;
 import com.skyhorsemanpower.auction.repository.RoundInfoRepository;
 import io.swagger.v3.oas.annotations.Operation;
@@ -51,7 +52,7 @@ public class AuctionController {
     // 경매 페이지 최초 진입 시 현재 데이터 조회 API
     @GetMapping("/initial-auction-page/{auctionUuid}")
     @Operation(summary = "경매 페이지 입장 시 사용되는 API", description = "경매 페이지 최초 진입 시 현재 데이터 조회")
-    public SuccessResponse<RoundInfoResponseVo> initialAuctionPage(
+    public SuccessResponse<RoundInfo> initialAuctionPage(
             @PathVariable("auctionUuid") String auctionUuid) {
         return new SuccessResponse<>(roundInfoRepository.findFirstByAuctionUuidOrderByCreatedAtDesc(auctionUuid).orElseThrow(
                 () -> new CustomException(ResponseStatus.NO_DATA)));

--- a/src/main/java/com/skyhorsemanpower/auction/repository/AuctionHistoryReactiveRepository.java
+++ b/src/main/java/com/skyhorsemanpower/auction/repository/AuctionHistoryReactiveRepository.java
@@ -1,6 +1,6 @@
 package com.skyhorsemanpower.auction.repository;
 
-import com.skyhorsemanpower.auction.data.vo.domain.AuctionHistory;
+import com.skyhorsemanpower.auction.domain.AuctionHistory;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.data.mongodb.repository.Tailable;

--- a/src/main/java/com/skyhorsemanpower/auction/repository/AuctionHistoryRepository.java
+++ b/src/main/java/com/skyhorsemanpower/auction/repository/AuctionHistoryRepository.java
@@ -1,7 +1,7 @@
 package com.skyhorsemanpower.auction.repository;
 
 import com.skyhorsemanpower.auction.data.projection.CheckBiddingPriceProjection;
-import com.skyhorsemanpower.auction.data.vo.domain.AuctionHistory;
+import com.skyhorsemanpower.auction.domain.AuctionHistory;
 import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/skyhorsemanpower/auction/repository/RoundInfoReactiveRepository.java
+++ b/src/main/java/com/skyhorsemanpower/auction/repository/RoundInfoReactiveRepository.java
@@ -1,7 +1,7 @@
 package com.skyhorsemanpower.auction.repository;
 
 import com.skyhorsemanpower.auction.data.vo.RoundInfoResponseVo;
-import com.skyhorsemanpower.auction.data.vo.domain.RoundInfo;
+import com.skyhorsemanpower.auction.domain.RoundInfo;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.data.mongodb.repository.Tailable;

--- a/src/main/java/com/skyhorsemanpower/auction/repository/RoundInfoRepository.java
+++ b/src/main/java/com/skyhorsemanpower/auction/repository/RoundInfoRepository.java
@@ -1,11 +1,14 @@
 package com.skyhorsemanpower.auction.repository;
 
 import com.skyhorsemanpower.auction.data.vo.RoundInfoResponseVo;
-import com.skyhorsemanpower.auction.data.vo.domain.RoundInfo;
+import com.skyhorsemanpower.auction.domain.RoundInfo;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import javax.swing.text.html.Option;
 import java.util.Optional;
 
 public interface RoundInfoRepository extends MongoRepository<RoundInfo, String> {
     Optional<RoundInfoResponseVo> findFirstByAuctionUuidOrderByCreatedAtDesc(String auctionUuid);
+
+    Optional<RoundInfo> findByAuctionUuidAndRound(String auctionUuid, int round);
 }

--- a/src/main/java/com/skyhorsemanpower/auction/repository/RoundInfoRepository.java
+++ b/src/main/java/com/skyhorsemanpower/auction/repository/RoundInfoRepository.java
@@ -8,7 +8,7 @@ import javax.swing.text.html.Option;
 import java.util.Optional;
 
 public interface RoundInfoRepository extends MongoRepository<RoundInfo, String> {
-    Optional<RoundInfoResponseVo> findFirstByAuctionUuidOrderByCreatedAtDesc(String auctionUuid);
+    Optional<RoundInfo> findFirstByAuctionUuidOrderByCreatedAtDesc(String auctionUuid);
 
-    Optional<RoundInfo> findByAuctionUuidAndRound(String auctionUuid, int round);
+//    Optional<RoundInfo> findFirstByAuctionUuidAndRoundOrderByCreatedAtDesc(String auctionUuid, int round);
 }

--- a/src/main/java/com/skyhorsemanpower/auction/status/RoundTimeEnum.java
+++ b/src/main/java/com/skyhorsemanpower/auction/status/RoundTimeEnum.java
@@ -1,0 +1,14 @@
+package com.skyhorsemanpower.auction.status;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RoundTimeEnum {
+    SECONDS_15(15),
+    SECONDS_30(30),
+    SECONDS_45(45),
+    SECONDS_60(60);
+    private final int second;
+}

--- a/src/main/java/com/skyhorsemanpower/auction/status/StandbyTimeEnum.java
+++ b/src/main/java/com/skyhorsemanpower/auction/status/StandbyTimeEnum.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum StandbyTimeEnum {
-    SECONDS_15(-15),
-    SECONDS_30(-30);
+    SECONDS_15(15),
+    SECONDS_30(30);
     private final int second;
 }


### PR DESCRIPTION
#179 
서비스 계층 위주로 보시면 될 듯 합니다.

입찰 시 다음 조건을 확인합니다.
1. `roundStartTime`<= 입찰 시간(입찰 API를 요청한 시간) <= `roundEndTime`
2. `남은 인원 수(leftNumberOfParticipants)` >= 1
3. (`입력한 입찰가` == `현재 round의 입찰가`) && (`입력 라운드` == `현재 라운드`)

위 조건을 통과하면 `auction_history`에 저장되고 `round_info` 갱신이 진행됩니다.
`round_info` 갱신 로직은 다음과 같습니다.
- `남은 인원 수(leftNumberOfParticipants)` >= 1 인 경우에는 현재 라운드에서 남은 인원 수(leftNumberOfParticipants)`를 하나 빼줍니다.
- `남은 인원 수(leftNumberOfParticipants)` == 0 인 경우에는 다음 라운드로 갱신됩니다.

실제 입찰을 진행하면 다음처럼 `남은 인원 수(leftNumberOfParticipants)`가 감소하고 다음 라운드로 가는 경우에는 전체가 갱신되는 것을 확인할 수 있습니다.
또한, 이번 라운드가 끝나면 대기 시간(15초) 동안 입찰을 못 합니다.

![image](https://github.com/SKY-HORSE-MAN-POWER/BE_Auction/assets/128444378/bccebd8c-5924-4489-b937-5137da43c1a8)
