### PR TITLE
Feature/#183 경매 마감 API 구현

### DIFF
--- a/src/main/java/com/skyhorsemanpower/auction/application/AuctionService.java
+++ b/src/main/java/com/skyhorsemanpower/auction/application/AuctionService.java
@@ -5,4 +5,5 @@ import com.skyhorsemanpower.auction.data.dto.*;
 public interface AuctionService {
     void offerBiddingPrice(OfferBiddingPriceDto offerBiddingPriceDto);
 
+    void auctionClose(String auctionUuid);
 }

--- a/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
@@ -86,12 +86,12 @@ public class AuctionServiceImpl implements AuctionService {
         // 마감 로직
         // 마지막 라운드 입찰 이력
         List<AuctionHistory> lastRoundAuctionHistory = auctionHistoryRepository.
-                findByAuctionUuidAndRoundOrderByBiddingTimeDesc(auctionUuid, round);
+                findByAuctionUuidAndRoundOrderByBiddingTime(auctionUuid, round);
         log.info("Last Round Auction History >>> {}", lastRoundAuctionHistory.toString());
 
         // 마지막 - 1 라운드 입찰 이력
         List<AuctionHistory> beforeLastRoundAuctionHistory = auctionHistoryRepository.
-                findByAuctionUuidAndRoundOrderByBiddingTimeDesc(auctionUuid, round - 1);
+                findByAuctionUuidAndRoundOrderByBiddingTime(auctionUuid, round - 1);
         log.info("Before Last Round Auction History >>> {}", beforeLastRoundAuctionHistory.toString());
 
         // 마지막 라운드 입찰자를 낙찰자로 고정

--- a/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
@@ -159,13 +159,23 @@ public class AuctionServiceImpl implements AuctionService {
         checkBiddingTime(roundInfo.getRoundStartTime(), roundInfo.getRoundEndTime());
         log.info("입찰 시간 통과");
 
-        // 조건2. 남은 인원이 1 이상
+        // 조건2. 해당 라운드에 참여 여부
+        checkBiddingRound(offerBiddingPriceDto.getBiddingUuid(), offerBiddingPriceDto.getRound());
+        log.info("현재 라운드에 참여한 적 없음");
+
+        // 조건3. 남은 인원이 1 이상
         checkLeftNumberOfParticipant(roundInfo.getLeftNumberOfParticipants());
         log.info("남은 인원 통과");
 
-        // 조건3. round 입찰가와 입력한 입찰가 확인
+        // 조건4. round 입찰가와 입력한 입찰가 확인
         checkRoundAndBiddingPrice(offerBiddingPriceDto, roundInfo);
         log.info("라운드 및 입찰가 통과");
+    }
+
+    private void checkBiddingRound(String biddingUuid, int round) {
+        if(auctionHistoryRepository.findByBiddingUuidAndRound(biddingUuid, round).isPresent()) {
+            throw new CustomException(ResponseStatus.ALREADY_BID_IN_ROUND);
+        };
     }
 
     private void checkLeftNumberOfParticipant(Long leftNumberOfParticipants) {

--- a/src/main/java/com/skyhorsemanpower/auction/common/exception/ResponseStatus.java
+++ b/src/main/java/com/skyhorsemanpower/auction/common/exception/ResponseStatus.java
@@ -40,6 +40,9 @@ public enum ResponseStatus {
     // 입찰자를 다 모집한 경우
     FULL_PARTICIPANTS(404, "현 라운드는 입찰자가 다 찼습니다."),
 
+    // 이번 라운드에 입찰하고 또 한 경우
+    ALREADY_BID_IN_ROUND(404, "이미 이번 라운드에 입찰하셨습니다."),
+
     // 예외 테스트 용
     EXCEPTION_TEST(500, "예외 테스트") ;
 

--- a/src/main/java/com/skyhorsemanpower/auction/domain/AuctionCloseState.java
+++ b/src/main/java/com/skyhorsemanpower/auction/domain/AuctionCloseState.java
@@ -1,0 +1,26 @@
+package com.skyhorsemanpower.auction.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@NoArgsConstructor
+@ToString
+@Document(collection = "auction_close_state")
+public class AuctionCloseState {
+    @Id
+    private String auctionCloseStateId;
+
+    private String auctionUuid;
+    private boolean auctionCloseState;
+
+    @Builder
+    public AuctionCloseState(String auctionUuid, boolean auctionCloseState) {
+        this.auctionUuid = auctionUuid;
+        this.auctionCloseState = auctionCloseState;
+    }
+}

--- a/src/main/java/com/skyhorsemanpower/auction/kafka/KafkaProducerCluster.java
+++ b/src/main/java/com/skyhorsemanpower/auction/kafka/KafkaProducerCluster.java
@@ -1,0 +1,32 @@
+package com.skyhorsemanpower.auction.kafka;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaProducerCluster {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void sendMessage(String topicName, Object object) {
+        CompletableFuture<SendResult<String, Object>> future =
+            kafkaTemplate.send(topicName, object);
+
+        future.whenComplete((result, ex) -> {
+            if (ex == null) {
+                log.info("producer: success >>> message: {}, offset: {}",
+                    result.getProducerRecord().value().toString(),
+                    result.getRecordMetadata().offset());
+            } else {
+                log.info("producer: failure >>> message: {}", ex.getMessage());
+            }
+        });
+    }
+}

--- a/src/main/java/com/skyhorsemanpower/auction/kafka/KafkaProducerConfig.java
+++ b/src/main/java/com/skyhorsemanpower/auction/kafka/KafkaProducerConfig.java
@@ -1,0 +1,34 @@
+package com.skyhorsemanpower.auction.kafka;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapAddress;
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/com/skyhorsemanpower/auction/kafka/Topics.java
+++ b/src/main/java/com/skyhorsemanpower/auction/kafka/Topics.java
@@ -1,0 +1,27 @@
+package com.skyhorsemanpower.auction.kafka;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Topics {
+    NOTIFICATION_SERVICE(Constant.NOTIFICATION_SERVICE),
+    CHAT_SERVICE(Constant.CHAT_SERVICE),
+    AUCTION_POST_SERVICE(Constant.AUCTION_POST_SERVICE),
+    PAYMENT_SERVICE(Constant.PAYMENT_SERVICE),
+    SUCCESSFUL_BID(Constant.SUCCESSFUL_BID),
+    SUCCESSFUL_BID_ALARM(Constant.SUCCESSFUL_BID_ALARM);
+    ;
+
+    public static class Constant {
+        public static final String NOTIFICATION_SERVICE = "alarm-topic";
+        public static final String CHAT_SERVICE = "chat-topic";
+        public static final String AUCTION_POST_SERVICE = "new-auction-post-topic";
+        public static final String PAYMENT_SERVICE = "event-preview-topic";
+        public static final String SUCCESSFUL_BID = "successful-bid-topic";
+        public static final String SUCCESSFUL_BID_ALARM = "successful-bid-alarm-topic";
+    }
+
+    private final String topic;
+}

--- a/src/main/java/com/skyhorsemanpower/auction/kafka/dto/SuccessfulBidDto.java
+++ b/src/main/java/com/skyhorsemanpower/auction/kafka/dto/SuccessfulBidDto.java
@@ -1,6 +1,8 @@
 package com.skyhorsemanpower.auction.kafka.dto;
 
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.skyhorsemanpower.auction.status.AuctionStateEnum;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -9,6 +11,8 @@ import lombok.ToString;
 import java.math.BigDecimal;
 import java.util.List;
 
+@JsonSerialize
+@JsonDeserialize
 @NoArgsConstructor
 @ToString
 public class SuccessfulBidDto {
@@ -18,7 +22,8 @@ public class SuccessfulBidDto {
     private AuctionStateEnum auctionState;
 
     @Builder
-    public SuccessfulBidDto(String auctionUuid, List<String> memberUuids, BigDecimal price, AuctionStateEnum auctionState) {
+    public SuccessfulBidDto(String auctionUuid, List<String> memberUuids,
+                            BigDecimal price, AuctionStateEnum auctionState) {
         this.auctionUuid = auctionUuid;
         this.memberUuids = memberUuids;
         this.price = price;

--- a/src/main/java/com/skyhorsemanpower/auction/kafka/dto/SuccessfulBidDto.java
+++ b/src/main/java/com/skyhorsemanpower/auction/kafka/dto/SuccessfulBidDto.java
@@ -1,21 +1,19 @@
 package com.skyhorsemanpower.auction.kafka.dto;
 
-
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.skyhorsemanpower.auction.status.AuctionStateEnum;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import java.math.BigDecimal;
 import java.util.List;
 
-@JsonSerialize
-@JsonDeserialize
+@Getter
 @NoArgsConstructor
 @ToString
 public class SuccessfulBidDto {
+
     private String auctionUuid;
     private List<String> memberUuids;
     private BigDecimal price;

--- a/src/main/java/com/skyhorsemanpower/auction/kafka/dto/SuccessfulBidDto.java
+++ b/src/main/java/com/skyhorsemanpower/auction/kafka/dto/SuccessfulBidDto.java
@@ -1,0 +1,27 @@
+package com.skyhorsemanpower.auction.kafka.dto;
+
+
+import com.skyhorsemanpower.auction.status.AuctionStateEnum;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@NoArgsConstructor
+@ToString
+public class SuccessfulBidDto {
+    private String auctionUuid;
+    private List<String> memberUuids;
+    private BigDecimal price;
+    private AuctionStateEnum auctionState;
+
+    @Builder
+    public SuccessfulBidDto(String auctionUuid, List<String> memberUuids, BigDecimal price, AuctionStateEnum auctionState) {
+        this.auctionUuid = auctionUuid;
+        this.memberUuids = memberUuids;
+        this.price = price;
+        this.auctionState = auctionState;
+    }
+}

--- a/src/main/java/com/skyhorsemanpower/auction/presentation/AuctionController.java
+++ b/src/main/java/com/skyhorsemanpower/auction/presentation/AuctionController.java
@@ -65,4 +65,13 @@ public class AuctionController {
             @PathVariable("auctionUuid") String auctionUuid) {
         return new SuccessResponse<>(redisService.getStandbyPage(auctionUuid));
     }
+
+    // 경매 마감 API 구현
+    @GetMapping("/auction-close/{auctionUuid}")
+    @Operation(summary = "경매 마감 API", description = "경매 마감 처리 후 결제 서비스에 메시지 전달")
+    public SuccessResponse<Object> auctionClose(
+            @PathVariable("auctionUuid") String auctionUuid) {
+        auctionService.auctionClose(auctionUuid);
+        return new SuccessResponse<>(null);
+    }
 }

--- a/src/main/java/com/skyhorsemanpower/auction/repository/AuctionCloseStateRepository.java
+++ b/src/main/java/com/skyhorsemanpower/auction/repository/AuctionCloseStateRepository.java
@@ -1,0 +1,12 @@
+package com.skyhorsemanpower.auction.repository;
+
+import com.skyhorsemanpower.auction.domain.AuctionCloseState;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AuctionCloseStateRepository extends MongoRepository<AuctionCloseState, String> {
+    Optional<AuctionCloseState> findByAuctionUuid(String auctionUuid);
+}

--- a/src/main/java/com/skyhorsemanpower/auction/repository/AuctionHistoryRepository.java
+++ b/src/main/java/com/skyhorsemanpower/auction/repository/AuctionHistoryRepository.java
@@ -22,4 +22,6 @@ public interface AuctionHistoryRepository extends MongoRepository<AuctionHistory
     Optional<CheckBiddingPriceProjection> findMaxBiddingPriceByAuctionUuid(String auctionUuid);
 
     List<AuctionHistory> findByAuctionUuidAndRoundOrderByBiddingTime(String auctionUuid, int round);
+
+    Optional<AuctionHistory> findByBiddingUuidAndRound(String biddingUuid, int round);
 }

--- a/src/main/java/com/skyhorsemanpower/auction/repository/AuctionHistoryRepository.java
+++ b/src/main/java/com/skyhorsemanpower/auction/repository/AuctionHistoryRepository.java
@@ -21,5 +21,5 @@ public interface AuctionHistoryRepository extends MongoRepository<AuctionHistory
     })
     Optional<CheckBiddingPriceProjection> findMaxBiddingPriceByAuctionUuid(String auctionUuid);
 
-    List<AuctionHistory> findByAuctionUuidAndRoundOrderByBiddingTimeDesc(String auctionUuid, int round);
+    List<AuctionHistory> findByAuctionUuidAndRoundOrderByBiddingTime(String auctionUuid, int round);
 }

--- a/src/main/java/com/skyhorsemanpower/auction/repository/AuctionHistoryRepository.java
+++ b/src/main/java/com/skyhorsemanpower/auction/repository/AuctionHistoryRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -19,4 +20,6 @@ public interface AuctionHistoryRepository extends MongoRepository<AuctionHistory
             "{ '$project': { 'biddingPrice': 1 } }"
     })
     Optional<CheckBiddingPriceProjection> findMaxBiddingPriceByAuctionUuid(String auctionUuid);
+
+    List<AuctionHistory> findByAuctionUuidAndRoundOrderByBiddingTimeDesc(String auctionUuid, int round);
 }

--- a/src/main/java/com/skyhorsemanpower/auction/status/AuctionStateEnum.java
+++ b/src/main/java/com/skyhorsemanpower/auction/status/AuctionStateEnum.java
@@ -6,10 +6,14 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum AuctionStateEnum {
+    // 경매 진행 전
+    BEFORE_AUCTION,
     // 경매 진행 중
     AUCTION_IS_IN_PROGRESS,
-    // 경매 정상 마감
+    // 경매 정상 종료
     AUCTION_NORMAL_CLOSING,
     // 경매 참여자 없음
     AUCTION_NO_PARTICIPANTS,
+    // 경매 비정상 종료
+    AUCTION_ABNORMAL_CLOSING
 }


### PR DESCRIPTION
`라운드 남은 시간 == 0`이 된 순간 요청하는 경매 마감 API 구현했습니다.

`n`명의  유저가 경매 마감 순간을 확인하고 있어 `n`번의 경매 마감 API가 요청되더라도 `auction_close_state` 도큐먼트를 이용해서 한 번만 진행되도록 했습니다.

최초 경매 마감 처리 시, `auction_close_state` 도큐먼트에 `auctionUuid`에 따라 `마감 처리 여부`를 저장합니다. 마감된 경매에 대해서 다시 마감 처리가 들어오면 경매 처리가 진행되지 않도록 구현했습니다.

마감 로직은 다음과 같습니다.
- `auction_history`에서 `auctionUuid` 일치하는 도큐먼트 리스트 조회
- `i`라운드 도큐먼트와 `i-1` 라운드 도큐먼트 리스트 들을 조회(`i`가 마지막 라운드)
- `round_info` 조회를 통해 `낙찰 가능자 수`를 조회한다.
- `i`라운드 도큐먼트 리스트에서 낙찰자를 낙찰자 list에 저장한다.
- `i-1` 라운드 도큐먼트 리스트에서 `createdAt` 오름차순 기준으로 낙찰자 리스트에 uuid를 추가한다.(입찰 순으로 넣어줘야 하기 때문에 오름차순)
	- 중복검사로 중복을 없애고 `낙찰자 list 길이 == 낙찰 가능자 수` 될 때 까지 반복한다.
	- 낙찰자 list 완성
- 낙찰가는 `i-1` 라운드의 입찰가로 저장한다.
- 카프카 메세지로 결제 서비스에 `낙찰자 list`과 `낙찰가`를 보낸다.

결제 서비스로 카프카 메시지가 정상적으로 보내집니다.
![image](https://github.com/SKY-HORSE-MAN-POWER/BE_Auction/assets/128444378/d2631d8b-5526-4011-8fb5-47c417b37241)
