### PR TITLE
Feature/#194 첫 라운드에 마감된 경매 마감 로직 구현

### DIFF
--- a/src/main/java/com/skyhorsemanpower/auction/quartz/data/MemberUuidsAndPrice.java
+++ b/src/main/java/com/skyhorsemanpower/auction/quartz/data/MemberUuidsAndPrice.java
@@ -1,0 +1,14 @@
+package com.skyhorsemanpower.auction.quartz.data;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.Set;
+
+@Getter
+@Builder
+public class MemberUuidsAndPrice {
+    private Set<String> memberUuids;
+    private BigDecimal price;
+}


### PR DESCRIPTION
기존에 로직은 첫 라운드를 넘긴 경우만 경매 마감 로직 구현을 하여 이전 라운드에서 정보를 조회할 때, 에러가 발생했습니다.

첫 라운드에 마감된 경매 마감된 경우도 고려하여 마감 로직을 구현하였습니다.