### PR TITLE
refactor: 입찰 검사 인자에 auctionUuid 추가(#210)

### DIFF
--- a/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
@@ -196,7 +196,8 @@ public class AuctionServiceImpl implements AuctionService {
         log.info("입찰 시간 통과");
 
         // 조건2. 해당 라운드에 참여 여부
-        checkBiddingRound(offerBiddingPriceDto.getBiddingUuid(), offerBiddingPriceDto.getRound());
+        checkBiddingRound(offerBiddingPriceDto.getAuctionUuid(), offerBiddingPriceDto.getBiddingUuid(),
+                offerBiddingPriceDto.getRound());
         log.info("현재 라운드에 참여한 적 없음");
 
         // 조건3. 남은 인원이 1 이상
@@ -208,8 +209,9 @@ public class AuctionServiceImpl implements AuctionService {
         log.info("라운드 및 입찰가 통과");
     }
 
-    private void checkBiddingRound(String biddingUuid, int round) {
-        if (auctionHistoryRepository.findByBiddingUuidAndRound(biddingUuid, round).isPresent()) {
+    private void checkBiddingRound(String auctionUuid, String biddingUuid, int round) {
+        if (auctionHistoryRepository.findByAuctionUuidAndBiddingUuidAndRound(
+                auctionUuid, biddingUuid, round).isPresent()) {
             throw new CustomException(ResponseStatus.ALREADY_BID_IN_ROUND);
         }
     }

--- a/src/main/java/com/skyhorsemanpower/auction/repository/AuctionHistoryRepository.java
+++ b/src/main/java/com/skyhorsemanpower/auction/repository/AuctionHistoryRepository.java
@@ -23,7 +23,7 @@ public interface AuctionHistoryRepository extends MongoRepository<AuctionHistory
 
     List<AuctionHistory> findByAuctionUuidAndRoundOrderByBiddingTime(String auctionUuid, int round);
 
-    Optional<AuctionHistory> findByBiddingUuidAndRound(String biddingUuid, int round);
+    Optional<AuctionHistory> findByAuctionUuidAndBiddingUuidAndRound(String auctionUuid, String biddingUuid, int round);
 
     Optional<AuctionHistory> findFirstByAuctionUuidOrderByBiddingTimeDesc(String auctionUuid);
 }


### PR DESCRIPTION
`auctionUuid`의 특정 `round`에서 `bidderUuid`인 입찰자가 입찰한 이력이 있는 지 확인하는 로직을 추가했습니다.
기존에는 `auctionUuid`이 없이 `round`와 `bidderUuid`로만 체크해서 다른 경매에 처음 입찰하는 경우에도 예외가 발생했습니다.