### PR TITLE
Feature/#205 `timeout`, `heartbeat` 조정 및 액추에이터 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,9 @@ dependencies {
 
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// actuator
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/com/skyhorsemanpower/auction/status/AuctionTimeEnum.java
+++ b/src/main/java/com/skyhorsemanpower/auction/status/AuctionTimeEnum.java
@@ -1,0 +1,15 @@
+package com.skyhorsemanpower.auction.status;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuctionTimeEnum {
+    MINUTES_01(1),
+    MINUTES_30(30),
+    MINUTES_60(60),
+    MINUTES_120(120);
+
+    private final int minute;
+}


### PR DESCRIPTION
- `timeout` 과 `heartbeat` 차이
    - `timeout`
        - `timeout`시간 동안 아무 이벤트도 발생하지 않으면 에러를 발생시키고 연결을 끊습니다.
    - `heartbeat`
        - `heartbeat` 주기마다 연결이 유지됐는지 여부를 알려줍니다.
- 저희는 `connection` 요청 자체를 최소화 해야 하기 때문에 `timeout` 을 경매 최대 시간인 2시간으로 줘야 할 것 같습니다.
    - `heartbeat`만 쓰는 경우에 연결이 죽으면 재연결 요청이 와서 `connection`을 추가로 물게 됩니다.