### PR TITLE
Feature/#223 경매 마감 후, 본인이 경매 낙찰 여부 조회 API 구현

### DIFF
--- a/src/main/java/com/skyhorsemanpower/auction/application/AuctionService.java
+++ b/src/main/java/com/skyhorsemanpower/auction/application/AuctionService.java
@@ -1,6 +1,7 @@
 package com.skyhorsemanpower.auction.application;
 
 import com.skyhorsemanpower.auction.data.dto.*;
+import com.skyhorsemanpower.auction.data.vo.AuctionResultResponseVo;
 
 public interface AuctionService {
     void offerBiddingPrice(OfferBiddingPriceDto offerBiddingPriceDto);
@@ -8,4 +9,6 @@ public interface AuctionService {
     void auctionClose(String auctionUuid);
 
     void auctionStateChangeTrue(String auctionUuid);
+
+    AuctionResultResponseVo auctionResult(String uuid, String auctionUuid);
 }

--- a/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
@@ -2,6 +2,7 @@ package com.skyhorsemanpower.auction.application.impl;
 
 import com.skyhorsemanpower.auction.application.AuctionService;
 import com.skyhorsemanpower.auction.common.exception.CustomException;
+import com.skyhorsemanpower.auction.data.vo.AuctionResultResponseVo;
 import com.skyhorsemanpower.auction.domain.AuctionCloseState;
 import com.skyhorsemanpower.auction.domain.AuctionResult;
 import com.skyhorsemanpower.auction.domain.RoundInfo;
@@ -25,6 +26,7 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @Service
@@ -220,6 +222,25 @@ public class AuctionServiceImpl implements AuctionService {
         } catch (Exception e) {
             throw new CustomException(ResponseStatus.MONGODB_ERROR);
         }
+    }
+
+    @Override
+    public AuctionResultResponseVo auctionResult(String uuid, String auctionUuid) {
+        Optional<AuctionResult> auctionResult = auctionResultRepository.
+                findByAuctionUuidAndMemberUuidsContains(auctionUuid, uuid);
+
+        // 낙찰자에 포함되지 않는 경우
+        if (auctionResult.isEmpty()) {
+            log.info("Auction Result is not exist. not bidder");
+            return AuctionResultResponseVo.notBidder();
+        }
+
+        // 낙찰자에 포함된 경우
+        log.info("Auction Result >>> {}", auctionResult.toString());
+        return AuctionResultResponseVo.builder()
+                .isBidder(true)
+                .price(auctionResult.get().getPrice())
+                .build();
     }
 
     private void updateRoundInfo(RoundInfo roundInfo) {

--- a/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/auction/application/impl/AuctionServiceImpl.java
@@ -3,6 +3,7 @@ package com.skyhorsemanpower.auction.application.impl;
 import com.skyhorsemanpower.auction.application.AuctionService;
 import com.skyhorsemanpower.auction.common.exception.CustomException;
 import com.skyhorsemanpower.auction.domain.AuctionCloseState;
+import com.skyhorsemanpower.auction.domain.AuctionResult;
 import com.skyhorsemanpower.auction.domain.RoundInfo;
 import com.skyhorsemanpower.auction.kafka.KafkaProducerCluster;
 import com.skyhorsemanpower.auction.kafka.Topics;
@@ -35,6 +36,7 @@ public class AuctionServiceImpl implements AuctionService {
     private final RoundInfoRepository roundInfoRepository;
     private final AuctionCloseStateRepository auctionCloseStateRepository;
     private final KafkaProducerCluster producer;
+    private final AuctionResultRepository auctionResultRepository;
 
     @Override
     @Transactional
@@ -138,6 +140,14 @@ public class AuctionServiceImpl implements AuctionService {
                 .auctionUuid(auctionUuid)
                 .auctionCloseState(true)
                 .build());
+
+        // 경매 결과 저장
+        auctionResultRepository.save(AuctionResult.builder()
+                .auctionUuid(auctionUuid)
+                .memberUuids(memberUuids.stream().toList())
+                .price(price)
+                .build());
+        log.info("Auction Result Save!");
     }
 
     private MemberUuidsAndPrice getMemberUuidsAndPrice(int round, String auctionUuid, long numberOfParticipants) {

--- a/src/main/java/com/skyhorsemanpower/auction/data/vo/AuctionResultResponseVo.java
+++ b/src/main/java/com/skyhorsemanpower/auction/data/vo/AuctionResultResponseVo.java
@@ -1,0 +1,27 @@
+package com.skyhorsemanpower.auction.data.vo;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+public class AuctionResultResponseVo {
+    private boolean isBidder;
+    private BigDecimal price;
+
+    @Builder
+    public AuctionResultResponseVo(boolean isBidder, BigDecimal price) {
+        this.isBidder = isBidder;
+        this.price = price;
+    }
+
+    public static AuctionResultResponseVo notBidder() {
+        return AuctionResultResponseVo.builder()
+                .isBidder(false)
+                .price(BigDecimal.ZERO)
+                .build();
+    }
+}

--- a/src/main/java/com/skyhorsemanpower/auction/domain/AuctionResult.java
+++ b/src/main/java/com/skyhorsemanpower/auction/domain/AuctionResult.java
@@ -1,0 +1,31 @@
+package com.skyhorsemanpower.auction.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@ToString
+@Document(collection = "auction_result")
+public class AuctionResult {
+    @Id
+    private String auctionResultId;
+
+    private String auctionUuid;
+    private List<String> memberUuids;
+    private BigDecimal price;
+
+    @Builder
+    public AuctionResult(String auctionUuid, List<String> memberUuids, BigDecimal price) {
+        this.auctionUuid = auctionUuid;
+        this.memberUuids = memberUuids;
+        this.price = price;
+    }
+}

--- a/src/main/java/com/skyhorsemanpower/auction/presentation/AuctionController.java
+++ b/src/main/java/com/skyhorsemanpower/auction/presentation/AuctionController.java
@@ -5,6 +5,7 @@ import com.skyhorsemanpower.auction.common.SuccessResponse;
 import com.skyhorsemanpower.auction.common.exception.CustomException;
 import com.skyhorsemanpower.auction.common.exception.ResponseStatus;
 import com.skyhorsemanpower.auction.data.dto.OfferBiddingPriceDto;
+import com.skyhorsemanpower.auction.data.vo.AuctionResultResponseVo;
 import com.skyhorsemanpower.auction.data.vo.OfferBiddingPriceRequestVo;
 import com.skyhorsemanpower.auction.data.vo.RoundInfoResponseVo;
 import com.skyhorsemanpower.auction.domain.RoundInfo;
@@ -95,7 +96,8 @@ public class AuctionController {
     @Operation(summary = "경매 페이지 입장 시 사용되는 API", description = "경매 페이지 최초 진입 시 현재 데이터 조회")
     public SuccessResponse<RoundInfo> initialAuctionPage(
             @PathVariable("auctionUuid") String auctionUuid) {
-        return new SuccessResponse<>(roundInfoRepository.findFirstByAuctionUuidOrderByCreatedAtDesc(auctionUuid).orElseThrow(
+        return new SuccessResponse<>(roundInfoRepository.
+                findFirstByAuctionUuidOrderByCreatedAtDesc(auctionUuid).orElseThrow(
                 () -> new CustomException(ResponseStatus.NO_DATA)));
     }
 
@@ -104,7 +106,6 @@ public class AuctionController {
     @Operation(summary = "경매 마감 API", description = "경매 마감 처리 후 결제 서비스에 메시지 전달")
     public SuccessResponse<Object> auctionClose(
             @PathVariable("auctionUuid") String auctionUuid) {
-        log.info("Start>>>>>>>>>..");
         auctionService.auctionClose(auctionUuid);
         return new SuccessResponse<>(null);
     }
@@ -117,5 +118,14 @@ public class AuctionController {
         // round_info의 isActive를 true(진행 중)로 변경
         auctionService.auctionStateChangeTrue(auctionUuid);
         return new SuccessResponse<>(null);
+    }
+
+    // 유저에 따른 경매 결과 조회
+    @GetMapping("/result/{auctionUuid}")
+    @Operation(summary = "경매 결과 조회 API", description = "유저가 경매에 낙찰됐는가를 조회")
+    public SuccessResponse<AuctionResultResponseVo> auctionResult(
+            @RequestHeader String uuid,
+            @PathVariable("auctionUuid") String auctionUuid) {
+        return new SuccessResponse<>(auctionService.auctionResult(uuid, auctionUuid));
     }
 }

--- a/src/main/java/com/skyhorsemanpower/auction/presentation/AuctionController.java
+++ b/src/main/java/com/skyhorsemanpower/auction/presentation/AuctionController.java
@@ -104,6 +104,7 @@ public class AuctionController {
     @Operation(summary = "경매 마감 API", description = "경매 마감 처리 후 결제 서비스에 메시지 전달")
     public SuccessResponse<Object> auctionClose(
             @PathVariable("auctionUuid") String auctionUuid) {
+        log.info("Start>>>>>>>>>..");
         auctionService.auctionClose(auctionUuid);
         return new SuccessResponse<>(null);
     }

--- a/src/main/java/com/skyhorsemanpower/auction/quartz/AuctionClose.java
+++ b/src/main/java/com/skyhorsemanpower/auction/quartz/AuctionClose.java
@@ -4,6 +4,7 @@ import com.skyhorsemanpower.auction.common.exception.CustomException;
 import com.skyhorsemanpower.auction.common.exception.ResponseStatus;
 import com.skyhorsemanpower.auction.domain.AuctionCloseState;
 import com.skyhorsemanpower.auction.domain.AuctionHistory;
+import com.skyhorsemanpower.auction.domain.AuctionResult;
 import com.skyhorsemanpower.auction.domain.RoundInfo;
 import com.skyhorsemanpower.auction.kafka.KafkaProducerCluster;
 import com.skyhorsemanpower.auction.kafka.Topics;
@@ -13,6 +14,7 @@ import com.skyhorsemanpower.auction.kafka.data.dto.AuctionCloseDto;
 import com.skyhorsemanpower.auction.quartz.data.MemberUuidsAndPrice;
 import com.skyhorsemanpower.auction.repository.AuctionCloseStateRepository;
 import com.skyhorsemanpower.auction.repository.AuctionHistoryRepository;
+import com.skyhorsemanpower.auction.repository.AuctionResultRepository;
 import com.skyhorsemanpower.auction.repository.RoundInfoRepository;
 import com.skyhorsemanpower.auction.status.AuctionStateEnum;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +37,7 @@ public class AuctionClose implements Job {
     private final AuctionHistoryRepository auctionHistoryRepository;
     private final RoundInfoRepository roundInfoRepository;
     private final AuctionCloseStateRepository auctionCloseStateRepository;
+    private final AuctionResultRepository auctionResultRepository;
 
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
@@ -116,6 +119,14 @@ public class AuctionClose implements Job {
                 .auctionUuid(auctionUuid)
                 .auctionCloseState(true)
                 .build());
+
+        // 경매 결과 저장
+        auctionResultRepository.save(AuctionResult.builder()
+                .auctionUuid(auctionUuid)
+                .memberUuids(memberUuids.stream().toList())
+                .price(price)
+                .build());
+        log.info("Auction Result Save!");
     }
 
     private MemberUuidsAndPrice getMemberUuidsAndPrice(int round, String auctionUuid, long numberOfParticipants) {

--- a/src/main/java/com/skyhorsemanpower/auction/repository/AuctionResultRepository.java
+++ b/src/main/java/com/skyhorsemanpower/auction/repository/AuctionResultRepository.java
@@ -2,6 +2,11 @@ package com.skyhorsemanpower.auction.repository;
 
 import com.skyhorsemanpower.auction.domain.AuctionResult;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
+@Repository
 public interface AuctionResultRepository extends MongoRepository<AuctionResult, String> {
+    Optional<AuctionResult> findByAuctionUuidAndMemberUuidsContains(String auctionUuid, String memberUuid);
 }

--- a/src/main/java/com/skyhorsemanpower/auction/repository/AuctionResultRepository.java
+++ b/src/main/java/com/skyhorsemanpower/auction/repository/AuctionResultRepository.java
@@ -1,0 +1,7 @@
+package com.skyhorsemanpower.auction.repository;
+
+import com.skyhorsemanpower.auction.domain.AuctionResult;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface AuctionResultRepository extends MongoRepository<AuctionResult, String> {
+}


### PR DESCRIPTION
경매가 마감되고 본인이 경매에 낙찰됐는지 여부를 알려주는 API를 구현했습니다.

경매 마감 로직에 경매 결과를 저장하는 `auction_result` 컬렉션에 결과를 저장합니다.
![image](https://github.com/SKY-HORSE-MAN-POWER/BE_Auction/assets/128444378/230078f1-fc06-4be3-8843-e2f5c2821735)

경매 낙찰 여부 api를 요청하면 다음과 같이 옵니다.

<낙찰된 경우>
![image](https://github.com/SKY-HORSE-MAN-POWER/BE_Auction/assets/128444378/82cbf7c8-4e9e-4685-ac0d-71de30d95af0)

<낙찰 안된 경우>
![image](https://github.com/SKY-HORSE-MAN-POWER/BE_Auction/assets/128444378/a35f07f2-12a1-4371-9ecd-1eb9ad30f5bb)
