### PR TITLE
Feature/#214 다음 라운드 진입 시, 마지막 라운드 여부 추가

### DIFF
--- a/src/main/java/com/skyhorsemanpower/auction/domain/RoundInfo.java
+++ b/src/main/java/com/skyhorsemanpower/auction/domain/RoundInfo.java
@@ -30,11 +30,14 @@ public class RoundInfo {
     private Long numberOfParticipants;
     private Long leftNumberOfParticipants;
     private LocalDateTime createdAt;
+    private LocalDateTime auctionEndTime;
+    private Boolean isLastRound;
 
     @Builder
     public RoundInfo(String auctionUuid, Integer round, LocalDateTime roundStartTime, LocalDateTime roundEndTime,
                      BigDecimal incrementUnit, BigDecimal price, Boolean isActive, Long numberOfParticipants,
-                     Long leftNumberOfParticipants, LocalDateTime createdAt) {
+                     Long leftNumberOfParticipants, LocalDateTime createdAt,
+                     LocalDateTime auctionEndTime, Boolean isLastRound) {
         this.auctionUuid = auctionUuid;
         this.round = round;
         this.roundStartTime = roundStartTime;
@@ -45,6 +48,8 @@ public class RoundInfo {
         this.numberOfParticipants = numberOfParticipants;
         this.leftNumberOfParticipants = leftNumberOfParticipants;
         this.createdAt = LocalDateTime.now();
+        this.auctionEndTime = auctionEndTime;
+        this.isLastRound = isLastRound;
     }
 
     public static RoundInfo nextRoundUpdate(RoundInfo roundInfo) {
@@ -52,6 +57,10 @@ public class RoundInfo {
         LocalDateTime nextRoundStartTime = LocalDateTime.now().plusSeconds(StandbyTimeEnum.SECONDS_15.getSecond());
         LocalDateTime nextRoundEndTime = nextRoundStartTime.plusSeconds(RoundTimeEnum.SECONDS_60.getSecond());
         BigDecimal nextPrice = roundInfo.getPrice().add(roundInfo.getIncrementUnit());
+        LocalDateTime auctionEndTime = roundInfo.getAuctionEndTime();
+
+        // nextRoundStartTime <= auctionEndTime <= nextRoundEndTime 인 경우 다음 라운드가 마지막 라운드
+        boolean isLastRound = nextRoundStartTime.isBefore(auctionEndTime) && auctionEndTime.isBefore(nextRoundEndTime);
 
         return RoundInfo.builder()
                 .auctionUuid(roundInfo.getAuctionUuid())
@@ -63,6 +72,7 @@ public class RoundInfo {
                 .isActive(false)        // 대기 상태로 변경
                 .numberOfParticipants(roundInfo.getNumberOfParticipants())
                 .leftNumberOfParticipants(roundInfo.getNumberOfParticipants())
+                .isLastRound(isLastRound)
                 .build();
     }
 

--- a/src/main/java/com/skyhorsemanpower/auction/domain/RoundInfo.java
+++ b/src/main/java/com/skyhorsemanpower/auction/domain/RoundInfo.java
@@ -72,6 +72,7 @@ public class RoundInfo {
                 .isActive(false)        // 대기 상태로 변경
                 .numberOfParticipants(roundInfo.getNumberOfParticipants())
                 .leftNumberOfParticipants(roundInfo.getNumberOfParticipants())
+                .auctionEndTime(roundInfo.getAuctionEndTime())
                 .isLastRound(isLastRound)
                 .build();
     }
@@ -89,6 +90,8 @@ public class RoundInfo {
                 .isActive(true)
                 .numberOfParticipants(roundInfo.getNumberOfParticipants())
                 .leftNumberOfParticipants(nextNumberOfParticipants)
+                .auctionEndTime(roundInfo.getAuctionEndTime())
+                .isLastRound(roundInfo.getIsLastRound())
                 .build();
     }
 
@@ -103,6 +106,8 @@ public class RoundInfo {
                 .isActive(true)
                 .numberOfParticipants(roundInfo.getNumberOfParticipants())
                 .leftNumberOfParticipants(roundInfo.getLeftNumberOfParticipants())
+                .auctionEndTime(roundInfo.getAuctionEndTime())
+                .isLastRound(roundInfo.getIsLastRound())
                 .createdAt(LocalDateTime.now())
                 .build();
     }

--- a/src/main/java/com/skyhorsemanpower/auction/kafka/KafkaConsumerCluster.java
+++ b/src/main/java/com/skyhorsemanpower/auction/kafka/KafkaConsumerCluster.java
@@ -26,7 +26,7 @@ public class KafkaConsumerCluster {
     private final RoundInfoRepository roundInfoRepository;
     private final QuartzJobConfig quartzJobConfig;
 
-    @KafkaListener(topics = "1", groupId = "${spring.kafka.consumer.group-id}")
+    @KafkaListener(topics = Topics.Constant.INITIAL_AUCTION, groupId = "${spring.kafka.consumer.group-id}")
     public void initialAuction(@Payload LinkedHashMap<String, Object> message,
         @Headers MessageHeaders messageHeaders) {
         log.info("consumer: success >>> message: {}, headers: {}", message.toString(),
@@ -57,7 +57,7 @@ public class KafkaConsumerCluster {
         // Instant 타입을 LocalDateTime 변환
         LocalDateTime roundStartTime = DateTimeConverter.
                 instantToLocalDateTime(initialAuctionDto.getAuctionStartTime());
-        LocalDateTime auctionEndTime = roundStartTime.plusHours(AuctionTimeEnum.MINUTES_120.getMinute());
+        LocalDateTime auctionEndTime = roundStartTime.plusMinutes(AuctionTimeEnum.MINUTES_120.getMinute());
 
         RoundInfo roundinfo = RoundInfo.builder()
                 .auctionUuid(initialAuctionDto.getAuctionUuid())


### PR DESCRIPTION
라운드 갱신 시, `roundStartTime` <= `auctionEndTime` <= `roundEndTime` 인 경우에 `isLastRound` = true (마지막 라운드) 가 되도록 했습니다.

`isLastRound` 여부를 가지고 프론트 쪽에서 마지막 라운드 처리 해야합니다.

![image](https://github.com/SKY-HORSE-MAN-POWER/BE_Auction/assets/128444378/681c6149-8d58-4c5b-9005-4a7b6e278369)
