### PR TITLE
refactor: 스케줄링된 경매 마감 로직에 이미 마감된 경매인지 분기 추가(#248)

### DIFF
--- a/src/main/java/com/skyhorsemanpower/auction/kafka/KafkaConsumerCluster.java
+++ b/src/main/java/com/skyhorsemanpower/auction/kafka/KafkaConsumerCluster.java
@@ -25,7 +25,6 @@ import java.util.LinkedHashMap;
 public class KafkaConsumerCluster {
     private final RoundInfoRepository roundInfoRepository;
     private final QuartzJobConfig quartzJobConfig;
-//    private final AuctionCloseStateRepository auctionCloseStateRepository;
 
     @KafkaListener(topics = Topics.Constant.INITIAL_AUCTION, groupId = "${spring.kafka.consumer.group-id}")
     public void initialAuction(@Payload LinkedHashMap<String, Object> message,


### PR DESCRIPTION
현재 경매 마감 스케줄러에 이미 경매 마감 여부를 확인하지 않고 있습니다.
기존에는 `auction_close_state` 도큐먼트를 조회해서 경매 마감 여부를 통해 경매가 마감됐으면 경매 마감 로직을 진행하지 않았습니다.
지금은 `auction_close_state` 도큐먼트를 안 쓰기 때문에 삭제했습니다.
이제는 마감 여부를 `auction_unique` 테이블에서 조회해서 해야 합니다.
경매 마감 API가 호출되면 `auction_unique` 테이블에 저장하고 경매 마감을 진행하기 때문에 경매 마감 스케줄링 Job에서도 `auction_unique` 테이블을 조회해서 마감이 된 경우에는 경매 마감 로직을 진행하지 않게 해야 합니다.

경매 마감이 정상적으로 작동하는 경매 마감 API 서비스 로직에서 가져왔습니다.