### PR TITLE
refactor: 메시지의 auctionEndTime 이 현재 보다 과거이면 round_info 도큐먼트 저장 및 스케줄 등록 제한(#252)

### DIFF
--- a/src/test/java/com/skyhorsemanpower/auction/kafka/KafkaConsumerClusterTest.java
+++ b/src/test/java/com/skyhorsemanpower/auction/kafka/KafkaConsumerClusterTest.java
@@ -1,0 +1,82 @@
+package com.skyhorsemanpower.auction.kafka;
+
+import com.skyhorsemanpower.auction.config.QuartzJobConfig;
+import com.skyhorsemanpower.auction.domain.RoundInfo;
+import com.skyhorsemanpower.auction.kafka.data.dto.InitialAuctionDto;
+import com.skyhorsemanpower.auction.repository.RoundInfoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.SchedulerException;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.GenericMessage;
+
+import java.util.LinkedHashMap;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class KafkaConsumerClusterTest {
+
+    @Mock
+    private RoundInfoRepository roundInfoRepository;
+
+    @Mock
+    private QuartzJobConfig quartzJobConfig;
+
+    @InjectMocks
+    private KafkaConsumerCluster kafkaConsumerCluster;
+
+    private LinkedHashMap<String, Object> message;
+    private GenericMessage<LinkedHashMap<String, Object>> genericMessage;
+
+    @BeforeEach
+    void setUp() {
+        message = new LinkedHashMap<>();
+        message.put("auctionUuid", "test-uuid");
+        message.put("startPrice", "1000");
+        message.put("numberOfEventParticipants", 10);
+        message.put("auctionStartTime", System.currentTimeMillis() + 10000);
+        message.put("incrementUnit", "100");
+
+        // GenericMessage 객체 생성
+        genericMessage = new GenericMessage<>(message);
+    }
+
+    @Test
+    @DisplayName("메시지 수신 내용 중 auctionEndTime이 현재보다 미래인 경우(정상)")
+    void testInitialAuction_FutureEndTime() throws SchedulerException {
+        // Given
+        Long auctionEndTime = System.currentTimeMillis() + 20000;
+        message.put("auctionEndTime", auctionEndTime);
+
+        // When
+        kafkaConsumerCluster.initialAuction(message, genericMessage.getHeaders());
+
+        // Then
+        // 저장과 스케줄 등록 로직이 한 번 호출되야 한다.
+        verify(roundInfoRepository, times(1)).save(any(RoundInfo.class));
+        verify(quartzJobConfig, times(1)).schedulerUpdateAuctionStateJob(any(InitialAuctionDto.class));
+    }
+
+    @Test
+    @DisplayName("메시지 수신 내용 중 auctionEndTime이 현재보다 과거인 경우(비정상)")
+    void testInitialAuction_PastEndTime() throws SchedulerException {
+        // Given
+        Long auctionEndTime = System.currentTimeMillis() - 20000;
+        message.put("auctionEndTime", auctionEndTime);
+
+        // When
+        kafkaConsumerCluster.initialAuction(message, genericMessage.getHeaders());
+
+        // Then
+        // 저장과 스케줄 등록이 되면 안된다.
+        verify(roundInfoRepository, never()).save(any());
+        verify(quartzJobConfig, never()).schedulerUpdateAuctionStateJob(any());
+    }
+}


### PR DESCRIPTION
경매 서비스가 재시작 하는 상황입니다.
경매글 생성됐다는 메시지를 받고 경매 마감 처리를 위한 스케줄러 등록을 합니다.
재시작 하는 과정에서 기존 메시지를 받는데 이미 마감 처리를 한 것들은 안 하게 해야 합니다.

`auctionEndTime`이 현재 시간보다 과거면 `round_info` 도큐먼트 경매 초기값을 저장 및 스케줄러 등록하지 않고 현재 시간보다 미래면 수행합니다.

테스트 코드 @Mock, @ExtendWith(MockitoExtension.class) 의 설명 자료입니다.
@Mock 은 목 객체 선언을 위해 사용했고 해당 어노테이션을 사용하기 위해 @ExtendWith를 선언했습니다.

![image](https://github.com/SKY-HORSE-MAN-POWER/BE_Auction/assets/128444378/3fa377a5-5f67-4e7e-8830-659eab7aaabe)
